### PR TITLE
[#16][#2] Build event parser

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -92,6 +92,9 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-parser"
 ).map(_ % circeVersion)
 
+// Lens support
+libraryDependencies += "com.softwaremill.quicklens" % "quicklens_2.12" % "1.4.12"
+
 val kantanVersion = "0.4.0"
 
 // Core library, included automatically if any other module is imported.

--- a/src/main/scala/org/piggottfamily/cbb_explorer/models/ncaa/LineupEvent.scala
+++ b/src/main/scala/org/piggottfamily/cbb_explorer/models/ncaa/LineupEvent.scala
@@ -51,18 +51,18 @@ object LineupEvent {
     /** Gets the event information (either from team or opponent - can't be both) */
     def get_info: Option[String] = team.orElse(opponent)
     /** Gets the event information (either from team or opponent - can't be both) */
-    def info: Option[String] = get_info.getOrElse("")
+    def info: String = get_info.getOrElse("")
 
     /** Gets the date string associated with the event */
-    def get_date_str: Option[String] = info.map { ev_str =>
+    def get_date_str: Option[String] = get_info.map { ev_str =>
       ev_str.split(',')(0)
     }
     /** Gets the date string associated with the event */
     def date_str: String = get_date_str.getOrElse("")
   }
   object RawGameEvent {
-    def team(s: String): RawGameEvent = RawGameEvent(Some(s), None)
-    def opponent(s: String): RawGameEvent = RawGameEvent(None, Some(s))
+    def team(s: String, poss: Int): RawGameEvent = RawGameEvent(Some(s), None, Some(poss))
+    def opponent(s: String, poss: Int): RawGameEvent = RawGameEvent(None, Some(s), None, Some(poss))
     object Team {
       def unapply(x: RawGameEvent): Option[String] = x.team
     }

--- a/src/main/scala/org/piggottfamily/cbb_explorer/models/ncaa/LineupEvent.scala
+++ b/src/main/scala/org/piggottfamily/cbb_explorer/models/ncaa/LineupEvent.scala
@@ -49,12 +49,16 @@ object LineupEvent {
     opponent_possession: Option[Int] = None
   ) {
     /** Gets the event information (either from team or opponent - can't be both) */
-    def info: Option[String] = team.orElse(opponent)
+    def get_info: Option[String] = team.orElse(opponent)
+    /** Gets the event information (either from team or opponent - can't be both) */
+    def info: Option[String] = get_info.getOrElse("")
 
     /** Gets the date string associated with the event */
-    def get_date_str: String = info.map { ev_str =>
+    def get_date_str: Option[String] = info.map { ev_str =>
       ev_str.split(',')(0)
-    }.getOrElse("")
+    }
+    /** Gets the date string associated with the event */
+    def date_str: String = get_date_str.getOrElse("")
   }
   object RawGameEvent {
     def team(s: String): RawGameEvent = RawGameEvent(Some(s), None)

--- a/src/main/scala/org/piggottfamily/cbb_explorer/models/ncaa/LineupEvent.scala
+++ b/src/main/scala/org/piggottfamily/cbb_explorer/models/ncaa/LineupEvent.scala
@@ -41,12 +41,11 @@ object LineupEvent {
 
   /** List of game events, categorized by whether it was "for" the team or its opponent */
   case class RawGameEvent(
+    min: Double,
     /** The format is date,time,event*/
     team: Option[String] = None,
     /** The format is date,time,event*/
-    opponent: Option[String] = None,
-    team_possession: Option[Int] = None,
-    opponent_possession: Option[Int] = None
+    opponent: Option[String] = None
   ) {
     /** Gets the event information (either from team or opponent - can't be both) */
     def get_info: Option[String] = team.orElse(opponent)
@@ -59,10 +58,21 @@ object LineupEvent {
     }
     /** Gets the date string associated with the event */
     def date_str: String = get_date_str.getOrElse("")
+
+    /** Gets the score string associated with the event */
+    def get_score_str: Option[String] = get_info.flatMap { ev_str =>
+      ev_str.split(',') match {
+        case a if a.size > 1 => Some(a(1))
+        case _ => None
+      }
+    }
+    /** Gets the date score associated with the event */
+    def score_str: String = get_score_str.getOrElse("0-0")
+
   }
   object RawGameEvent {
-    def team(s: String, poss: Int): RawGameEvent = RawGameEvent(Some(s), None, Some(poss).filter(_ != 0))
-    def opponent(s: String, poss: Int): RawGameEvent = RawGameEvent(None, Some(s), None, Some(poss).filter(_ != 0))
+    def team(s: String, min: Double): RawGameEvent = RawGameEvent(min, Some(s), None)
+    def opponent(s: String, min: Double): RawGameEvent = RawGameEvent(min, None, Some(s))
     object Team {
       def unapply(x: RawGameEvent): Option[String] = x.team
     }

--- a/src/main/scala/org/piggottfamily/cbb_explorer/models/ncaa/LineupEvent.scala
+++ b/src/main/scala/org/piggottfamily/cbb_explorer/models/ncaa/LineupEvent.scala
@@ -61,8 +61,8 @@ object LineupEvent {
     def date_str: String = get_date_str.getOrElse("")
   }
   object RawGameEvent {
-    def team(s: String, poss: Int): RawGameEvent = RawGameEvent(Some(s), None, Some(poss))
-    def opponent(s: String, poss: Int): RawGameEvent = RawGameEvent(None, Some(s), None, Some(poss))
+    def team(s: String, poss: Int): RawGameEvent = RawGameEvent(Some(s), None, Some(poss).filter(_ != 0))
+    def opponent(s: String, poss: Int): RawGameEvent = RawGameEvent(None, Some(s), None, Some(poss).filter(_ != 0))
     object Team {
       def unapply(x: RawGameEvent): Option[String] = x.team
     }

--- a/src/main/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/EventUtils.scala
+++ b/src/main/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/EventUtils.scala
@@ -407,6 +407,20 @@ object EventUtils {
     }
   }
 
+  /** Flagrant foul */
+  object ParseFlagrantFoul {
+//TODO    
+    // New:
+    //"team": "06:43:00,55-79,Bruno Fernando, foul technical classa;2freethrow"
+    // Legacy:
+    //(haven't found any yet)
+    private val technical_foul_regex_new = "[^,]+,[^,]+,(.+), +foul technical.*".r
+    def unapply(x: String): Option[String] = Option(x) match {
+      case Some(technical_foul_regex_new(player)) => Some(player)
+      case _ => None
+    }
+  }
+
   /** Who was fouled? */
   object ParseFoulInfo {
     // New:

--- a/src/main/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/EventUtils.scala
+++ b/src/main/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/EventUtils.scala
@@ -63,7 +63,7 @@ object EventUtils {
     //RawGameEvent(Some("19:58:00,0-0,Bruno Fernando, jumpball won"), None),
     // Legacy: (none)
     private val jumpball_regex = "[^,]+,[^,]+,(.+), +jumpball (?:won|lost)".r
-    def unapply(x: Option[String]): Option[String] = x match {
+    def unapply(x: String): Option[String] = Option(x) match {
       case Some(jumpball_regex(player)) => Some(player)
       case _ => None
     }
@@ -77,7 +77,7 @@ object EventUtils {
     //"team": ""00:21,59-62,TEAM 30 Second Timeout""
     private val timeout_regex = "[^,]+,[^,]+,(.+) +Timeout".r
     private val timeout_regex_new = "[^,]+,[^,]+,(.+), +timeout.*".r
-    def unapply(x: Option[String]): Option[String] = x match {
+    def unapply(x: String): Option[String] = Option(x) match {
       case Some(timeout_regex(_)) => Some("TEAM")
       case Some(timeout_regex_new(_)) => Some("Team")
       case _ => None
@@ -101,7 +101,6 @@ object EventUtils {
   object ParseDunkMissed {
     //New:
     //Bruno Fernando, 2pt dunk missed
-    // Legacy:
     // Legacy:
     // WATKINS,MIKE missed Dunk
 
@@ -166,9 +165,9 @@ object EventUtils {
     // Old:
     // See above for all the combos, basically "made {not Free Throw}"
 
-    private val shot_made_regex = "[^,]+,[^,]+,(.+) made +(?!Free Throw)".r
-    private val shot_made_regex_new = "[^,]+,[^,]+,(.+), +[23]pt +.* +made".r
-    def unapply(x: Option[String]): Option[String] = x match {
+    private val shot_made_regex = "[^,]+,[^,]+,(.+) made +(?!Free Throw).*".r
+    private val shot_made_regex_new = "[^,]+,[^,]+,(.+), +[23]pt +(?:.* +)?made".r
+    def unapply(x: String): Option[String] = Option(x) match {
       case Some(shot_made_regex(player)) => Some(player)
       case Some(shot_made_regex_new(player)) => Some(player)
       case _ => None
@@ -182,9 +181,9 @@ object EventUtils {
     // Old:
     // See above for all the combos, basically "missed {not Free Throw}"
 
-    private val shot_missed_regex = "[^,]+,[^,]+,(.+) made +(?!Free Throw)".r
-    private val shot_missed_regex_new = "[^,]+,[^,]+,(.+), +[23]pt +.* +(missed|blocked)".r
-    def unapply(x: Option[String]): Option[String] = x match {
+    private val shot_missed_regex = "[^,]+,[^,]+,(.+) missed +(?!Free Throw).*".r
+    private val shot_missed_regex_new = "[^,]+,[^,]+,(.+), +[23]pt +(?:.* +)?(?:missed|blocked)".r
+    def unapply(x: String): Option[String] = Option(x) match {
       case Some(shot_missed_regex(player)) => Some(player)
       case Some(shot_missed_regex_new(player)) => Some(player)
       case _ => None
@@ -199,7 +198,7 @@ object EventUtils {
     //"team": "04:53,55-69,LAYMAN,JAKE Blocked Shot"
     private val blocked_shot_regex = "[^,]+,[^,]+,(.+) +Blocked Shot".r
     private val blocked_shot_regex_new = "[^,]+,[^,]+,(.+), +block".r
-    def unapply(x: Option[String]): Option[String] = x match {
+    def unapply(x: String): Option[String] = Option(x) match {
       case Some(blocked_shot_regex(player)) => Some(player)
       case Some(blocked_shot_regex_new(player)) => Some(player)
       case _ => None
@@ -208,7 +207,7 @@ object EventUtils {
 
   // Rebounding (can tell ORB vs DRB based on possession)
 
-  object Rebound {
+  object ParseRebound {
     // New:
     // Darryl Morsell, rebound defensive
     // Jalen Smith, rebound offensive
@@ -217,9 +216,9 @@ object EventUtils {
     // SMITH,JALEN Offensive Rebound
     // HARRAR,JOHN Defensive Rebound
 
-    private val rebound_regex = "[^,]+,[^,]+,(.+) +(Offensive|Defensive) +Turnover".r
+    private val rebound_regex = "[^,]+,[^,]+,(.+) +(?:Offensive|Defensive) +Rebound".r
     private val rebound_regex_new = "[^,]+,[^,]+,(.+), +rebound +.*".r
-    def unapply(x: Option[String]): Option[String] = x match {
+    def unapply(x: String): Option[String] = Option(x) match {
       case Some(rebound_regex(player)) => Some(player)
       case Some(rebound_regex_new(player)) => Some(player)
       case _ => None
@@ -230,28 +229,28 @@ object EventUtils {
 
   // Free throws
 
-  object FreeThrowMade {
-    //DREAD,MYLES made Free Throw
+  object ParseFreeThrowMade {
+    //New: (warning .. free throws can come in the wrong order)
     // Kevin Anderson, freethrow 2of2 made
     //Legacy:
-    //New: (warning .. free throws can come in the wrong order)
+    //DREAD,MYLES made Free Throw
     private val ft_made_regex = "[^,]+,[^,]+,(.+) made +Free Throw".r
-    private val ft_made_regex_new = "[^,]+,[^,]+,(.+), +freethrow ([0-9])of([0-9]) +.* +made".r
-    def unapply(x: Option[String]): Option[String] = x match {
+    private val ft_made_regex_new = "[^,]+,[^,]+,(.+), +freethrow [0-9]of[0-9] +(?:.* +)?made".r
+    def unapply(x: String): Option[String] = Option(x) match {
       case Some(ft_made_regex(player)) => Some(player)
       case Some(ft_made_regex_new(player)) => Some(player)
       case _ => None
     }
   }
 
-  object FreeThrowMissed {
+  object ParseFreeThrowMissed {
     //New: (warning .. free throws can come in the wrong order)
     // Kevin Anderson, freethrow 1of2 missed
     //Legacy:
     //DREAD,MYLES missed Free Throw
     private val ft_missed_regex = "[^,]+,[^,]+,(.+) missed +Free Throw".r
-    private val ft_missed_regex_new = "[^,]+,[^,]+,(.+), +freethrow ([0-9])of([0-9]) +.* +missed".r
-    def unapply(x: Option[String]): Option[String] = x match {
+    private val ft_missed_regex_new = "[^,]+,[^,]+,(.+), +freethrow [0-9]of[0-9] +(?:.* +)?missed".r
+    def unapply(x: String): Option[String] = Option(x) match {
       case Some(ft_missed_regex(player)) => Some(player)
       case Some(ft_missed_regex_new(player)) => Some(player)
       case _ => None
@@ -260,7 +259,7 @@ object EventUtils {
 
   // Turnover events
 
-  object Turnover {
+  object ParseTurnover {
       // New:
       // Bruno Fernando, turnover badpass
       // Joshua Tomaic, turnover lostball
@@ -271,7 +270,7 @@ object EventUtils {
 
       private val turnover_regex = "[^,]+,[^,]+,(.+) +Turnover".r
       private val turnover_regex_new = "[^,]+,[^,]+,(.+), +turnover +.*".r
-      def unapply(x: Option[String]): Option[String] = x match {
+      def unapply(x: String): Option[String] = Option(x) match {
         case Some(turnover_regex(player)) => Some(player)
         case Some(turnover_regex_new(player)) => Some(player)
         case _ => None
@@ -286,7 +285,7 @@ object EventUtils {
     //"team": "05:10,55-68,MASON III,FRANK Steal"
     private val stolen_regex = "[^,]+,[^,]+,(.+) +Steal".r
     private val stolen_regex_new = "[^,]+,[^,]+,(.+), +steal".r
-    def unapply(x: Option[String]): Option[String] = x match {
+    def unapply(x: String): Option[String] = Option(x) match {
       case Some(stolen_regex(player)) => Some(player)
       case Some(stolen_regex_new(player)) => Some(player)
       case _ => None
@@ -303,7 +302,7 @@ object EventUtils {
     //"opponent": "10:00,51-60,MYKHAILIUK,SVI Commits Foul"
     private val personal_foul_regex = "[^,]+,[^,]+,(.+) +Commits Foul".r
     private val personal_foul_regex_new = "[^,]+,[^,]+,(.+), +foul personal.*".r
-    def unapply(x: Option[String]): Option[String] = x match {
+    def unapply(x: String): Option[String] = Option(x) match {
       case Some(personal_foul_regex(player)) => Some(player)
       case Some(personal_foul_regex_new(player)) => Some(player)
       case _ => None
@@ -317,7 +316,7 @@ object EventUtils {
     // Legacy:
     //(haven't found any yet)
     private val technical_foul_regex_new = "[^,]+,[^,]+,(.+), +foul technical.*".r
-    def unapply(x: Option[String]): Option[String] = x match {
+    def unapply(x: String): Option[String] = Option(x) match {
       case Some(technical_foul_regex_new(player)) => Some(player)
       case _ => None
     }
@@ -330,7 +329,7 @@ object EventUtils {
     // Legacy:
     //(haven't found any yet)
     private val foul_info_regex_new = "[^,]+,[^,]+,(.+), +foulon".r
-    def unapply(x: Option[String]): Option[String] = x match {
+    def unapply(x: String): Option[String] = Option(x) match {
       case Some(foul_info_regex_new(player)) => Some(player)
       case _ => None
     }

--- a/src/main/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/EventUtils.scala
+++ b/src/main/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/EventUtils.scala
@@ -344,6 +344,7 @@ object EventUtils {
       case ParseShotMade(x) => Some(x)
       case ParseShotMissed(x) => Some(x)
       case ParseTurnover(x) => Some(x)
+      case _ => None
     }
   }
 
@@ -353,6 +354,7 @@ object EventUtils {
       case ParsePersonalFoul(x) => Some(x)
       case ParseStolen(x) => Some(x)
       case ParseShotBlocked(x) => Some(x)
+      case _ => None
     }
   }
 

--- a/src/main/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/EventUtils.scala
+++ b/src/main/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/EventUtils.scala
@@ -264,7 +264,6 @@ object EventUtils {
       case _ => None
     }
   }
-  //TODO: TOTEST
 
   /** Defensive rebound, including team/deadball etc */
   object ParseDefensiveRebound {
@@ -323,9 +322,6 @@ object EventUtils {
       case _ => None
     }
   }
-  //TODO: TOTEST
-
-  //TODO: categorize ORB vs DRB for easier stats collection
 
   // Free throws
 
@@ -365,7 +361,6 @@ object EventUtils {
       ParseFreeThrowMade.unapply(x)
     }
   }
-  //TODO TOTEST
 
   /** Presence of 1+ FTs in a possession (old format - will double count if split across clumps) */
   object ParseFreeThrowEvent {
@@ -384,7 +379,6 @@ object EventUtils {
       case _ => None
     }
   }
-  //TODO TOTEST
 
   // Turnover events
 
@@ -447,16 +441,16 @@ object EventUtils {
     private val technical_foul_regex = "[^,]+,[^,]+,(TEAM) +Commits Foul".r
     private val technical_foul_regex_new = "[^,]+,[^,]+,(.+), +foul technical.*".r
     def unapply(x: String): Option[String] = Option(x) match {
+      case Some(technical_foul_regex(player)) => Some(player)
       case Some(technical_foul_regex_new(player)) => Some(player)
       case _ => None
     }
   }
-//TODO: TOTEST
 
   /** Flagrant foul */
   object ParseFlagrantFoul {
     // New:
-    //"team": "03:42:00	Eric Carter, foul personal flagrant1;2freethrow	60-67"
+    //"team": "03:42:00,60-67,Eric Carter, foul personal flagrant1;2freethrow"
     // Legacy:
     //(haven't found any yet)
     private val flagrant_foul_regex_new = "[^,]+,[^,]+,(.+), +foul personal flagrant.*".r
@@ -465,7 +459,6 @@ object EventUtils {
       case _ => None
     }
   }
-//TODO: TOTEST
 
   /** Who was fouled? */
   object ParseFoulInfo {
@@ -495,7 +488,6 @@ object EventUtils {
       //(ORBs not needed becausee must be associated with one of the above actions)
     }
   }
-  //TODO TOTEST
 
   /** An offensive event that tells us who is which side in a possession */
   object ParseDefensiveActionEvent {
@@ -505,7 +497,6 @@ object EventUtils {
       //(Note there's insufficient info in fouls to use them here)
     }
   }
-  //TODO TOTEST
 
   /** A defensive event that provides context to an offensive action (eg turnovere) */
   object ParseDefensiveInfoEvent {
@@ -515,13 +506,10 @@ object EventUtils {
       case _ => None
     }
   }
-  //TODO TOTEST
 
   /** Any defensive event */
   object ParseDefensiveEvent {
     def unapply(x: String): Option[String] =
       ParseDefensiveActionEvent.unapply(x).orElse { ParseDefensiveInfoEvent.unapply(x) }
   }
-  //TODO TOTEST
-
 }

--- a/src/main/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/EventUtils.scala
+++ b/src/main/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/EventUtils.scala
@@ -359,7 +359,15 @@ object EventUtils {
     }
   }
 
-  /** Presence of 1+ FTs in a possession (old format - will double count is split across clumps) */
+  /** Any free throw attempt (missed or made) */
+  object ParseFreeThrowAttempt {
+    def unapply(x: String): Option[String] = ParseFreeThrowMissed.unapply(x).orElse {
+      ParseFreeThrowMade.unapply(x)
+    }
+  }
+  //TODO TOTEST
+
+  /** Presence of 1+ FTs in a possession (old format - will double count if split across clumps) */
   object ParseFreeThrowEvent {
     private val ft_start1_regex_new = "[^,]+,[^,]+,(.+), +freethrow 1of1 .*".r
     private val ft_start2_regex_new = "[^,]+,[^,]+,(.+), +freethrow 1of2 .*".r

--- a/src/main/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/EventUtils.scala
+++ b/src/main/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/EventUtils.scala
@@ -334,4 +334,26 @@ object EventUtils {
       case _ => None
     }
   }
+
+  // Useful
+
+  /** An offensive event that tells us who is starting a possession */
+  object ParseCommonOffensiveEvent {
+    def unapply(x: String): Option[String] = x match {
+      case ParseTimeout(x) => Some(x)
+      case ParseShotMade(x) => Some(x)
+      case ParseShotMissed(x) => Some(x)
+      case ParseTurnover(x) => Some(x)
+    }
+  }
+
+  /** An offensive event that tells us who is starting a possession */
+  object ParseCommonDefensiveEvent {
+    def unapply(x: String): Option[String] = x match {
+      case ParsePersonalFoul(x) => Some(x)
+      case ParseStolen(x) => Some(x)
+      case ParseShotBlocked(x) => Some(x)
+    }
+  }
+
 }

--- a/src/main/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/EventUtils.scala
+++ b/src/main/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/EventUtils.scala
@@ -33,18 +33,26 @@ object EventUtils {
     private val sub_regex_in = "(.+) +Enters Game".r
     private val sub_regex_in_new_format = "(.+), +substitution in".r
     def unapply(x: (Option[String], Option[String])): Option[String] = x match {
-      case (Some(sub_regex_in(player)), None) => Some(player)
-      case (Some(sub_regex_in_new_format(player)), None) => Some(player)
+      case (Some(player), None) => ParseTeamSubIn.unapply(player)
+      case _ => None
+    }
+    def unapply(x: String): Option[String] = x match {
+      case sub_regex_in(player) => Some(player)
+      case sub_regex_in_new_format(player) => Some(player)
       case _ => None
     }
   }
   /** Team (_not_ opponent) substitution out */
   object ParseTeamSubOut {
     private val sub_regex_out = "(.+) +Leaves Game".r
-    private val sub_regex_in_new_format = "(.+), +substitution out".r
+    private val sub_regex_out_new_format = "(.+), +substitution out".r
     def unapply(x: (Option[String], Option[String])): Option[String] = x match {
-      case (Some(sub_regex_out(player)), None) => Some(player)
-      case (Some(sub_regex_in_new_format(player)), None) => Some(player)
+      case (Some(player), None) => ParseTeamSubOut.unapply(player)
+      case _ => None
+    }
+    def unapply(x: String): Option[String] = x match {
+      case sub_regex_out(player) => Some(player)
+      case sub_regex_out_new_format(player) => Some(player)
       case _ => None
     }
   }
@@ -246,7 +254,7 @@ object EventUtils {
     // 19:09:00,29-38,Team, rebound defensivedeadball
     // Legacy:
     // HARRAR,JOHN Defensive Rebound
-//TODO; deadball rebounds are a problem in legacy mode
+    // (note legacy deadball rebounds aren't captured)
 
     private val rebound_regex = "[^,]+,[^,]+,(.+) +Offensive +Rebound".r
     private val rebound_regex_new = "[^,]+,[^,]+,(.+), +rebound +offensive.*".r
@@ -256,7 +264,7 @@ object EventUtils {
       case _ => None
     }
   }
-  //TODO: test
+  //TODO: TOTEST
 
   /** Defensive rebound, including team/deadball etc */
   object ParseDefensiveRebound {
@@ -265,7 +273,7 @@ object EventUtils {
     // 19:09:00,29-38,Team, rebound defensivedeadball
     // Legacy:
     // HARRAR,JOHN Defensive Rebound
-//TODO; deadball rebounds are a problem in legacy mode
+    // (note legacy deadball rebounds aren't captured)
 
     private val rebound_regex = "[^,]+,[^,]+,(.+) +Defensive +Rebound".r
     private val rebound_regex_new = "[^,]+,[^,]+,(.+), +rebound +defensive.*".r
@@ -315,6 +323,7 @@ object EventUtils {
       case _ => None
     }
   }
+  //TODO: TOTEST
 
   //TODO: categorize ORB vs DRB for easier stats collection
 
@@ -367,7 +376,7 @@ object EventUtils {
       case _ => None
     }
   }
-  //TODO test
+  //TODO TOTEST
 
   // Turnover events
 
@@ -434,7 +443,7 @@ object EventUtils {
       case _ => None
     }
   }
-//TODO: test
+//TODO: TOTEST
 
   /** Flagrant foul */
   object ParseFlagrantFoul {
@@ -448,7 +457,7 @@ object EventUtils {
       case _ => None
     }
   }
-//TODO: test
+//TODO: TOTEST
 
   /** Who was fouled? */
   object ParseFoulInfo {
@@ -478,7 +487,7 @@ object EventUtils {
       //(ORBs not needed becausee must be associated with one of the above actions)
     }
   }
-  //TODO test
+  //TODO TOTEST
 
   /** An offensive event that tells us who is which side in a possession */
   object ParseDefensiveActionEvent {
@@ -488,7 +497,7 @@ object EventUtils {
       //(Note there's insufficient info in fouls to use them here)
     }
   }
-  //TODO test
+  //TODO TOTEST
 
   /** A defensive event that provides context to an offensive action (eg turnovere) */
   object ParseDefensiveInfoEvent {
@@ -498,13 +507,13 @@ object EventUtils {
       case _ => None
     }
   }
-  //TODO test
+  //TODO TOTEST
 
   /** Any defensive event */
   object ParseDefensiveEvent {
     def unapply(x: String): Option[String] =
       ParseDefensiveActionEvent.unapply(x).orElse { ParseDefensiveInfoEvent.unapply(x) }
   }
-  //TODO test
+  //TODO TOTEST
 
 }

--- a/src/main/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/EventUtils.scala
+++ b/src/main/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/EventUtils.scala
@@ -207,16 +207,18 @@ object EventUtils {
 
   // Rebounding (can tell ORB vs DRB based on possession)
 
+  /** Uncategorized rebound, including team/deadball etc */
   object ParseRebound {
     // New:
     // Darryl Morsell, rebound defensive
     // Jalen Smith, rebound offensive
     // Team, rebound offensive team
+    // 09:48:00	Team, rebound offensivedeadball
     // Legacy:
     // SMITH,JALEN Offensive Rebound
     // HARRAR,JOHN Defensive Rebound
 
-    private val rebound_regex = "[^,]+,[^,]+,(.+) +(?:Offensive|Defensive) +Rebound".r
+    private val rebound_regex = "[^,]+,[^,]+,(.+) +(?:Offensive|Defensive|Deadball) +Rebound".r
     private val rebound_regex_new = "[^,]+,[^,]+,(.+), +rebound +.*".r
     def unapply(x: String): Option[String] = Option(x) match {
       case Some(rebound_regex(player)) => Some(player)
@@ -225,10 +227,29 @@ object EventUtils {
     }
   }
 
+  /** Occurs with an intermediate FT miss (ignore),  a block out of bounds, missed
+   * final FT off the defender? etc
+  */
+  object ParseTeamDeadballRebound {
+    // New:
+    //04:28:0,52-59,Team, rebound offensivedeadball
+    // Legacy:
+    // 04:33,46-45,TEAM Deadball Rebound
+
+    private val rebound_deadball_regex = "[^,]+,[^,]+,(.+) +Deadball +Rebound".r
+    private val rebound_deadball_regex_new = "[^,]+,[^,]+,(.+), +rebound offensivedeadball".r
+    def unapply(x: String): Option[String] = Option(x) match {
+      case Some(rebound_deadball_regex(player)) => Some(player)
+      case Some(rebound_deadball_regex_new(player)) => Some(player)
+      case _ => None
+    }
+  }
+
   //TODO: categorize ORB vs DRB for easier stats collection
 
   // Free throws
 
+  /** Any made free throw */
   object ParseFreeThrowMade {
     //New: (warning .. free throws can come in the wrong order)
     // Kevin Anderson, freethrow 2of2 made
@@ -243,6 +264,7 @@ object EventUtils {
     }
   }
 
+  /** Any missed free throw */
   object ParseFreeThrowMissed {
     //New: (warning .. free throws can come in the wrong order)
     // Kevin Anderson, freethrow 1of2 missed
@@ -253,6 +275,17 @@ object EventUtils {
     def unapply(x: String): Option[String] = Option(x) match {
       case Some(ft_missed_regex(player)) => Some(player)
       case Some(ft_missed_regex_new(player)) => Some(player)
+      case _ => None
+    }
+  }
+
+  /** (New format only) A missed free throw */
+  object ParseMiddleFreeThrowMissed {
+    private val ft_missed_middle2_regex_new = "[^,]+,[^,]+,(.+), +freethrow 1of2 +(?:.* +)?missed".r
+    private val ft_missed_middle3_regex_new = "[^,]+,[^,]+,(.+), +freethrow [12]of3 +(?:.* +)?missed".r
+    def unapply(x: String): Option[String] = Option(x) match {
+      case Some(ft_missed_middle2_regex_new(player)) => Some(player)
+      case Some(ft_missed_middle3_regex_new(player)) => Some(player)
       case _ => None
     }
   }
@@ -347,6 +380,7 @@ object EventUtils {
       case _ => None
     }
   }
+  //TODO test
 
   /** An offensive event that tells us who is starting a possession */
   object ParseCommonDefensiveEvent {
@@ -357,5 +391,6 @@ object EventUtils {
       case _ => None
     }
   }
+  //TODO test
 
 }

--- a/src/main/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/ExtractorUtils.scala
+++ b/src/main/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/ExtractorUtils.scala
@@ -76,11 +76,11 @@ object ExtractorUtils {
             old_format = is_old_format(player_name, state)
           )
 
-        case Model.OtherTeamEvent(min, score, poss, event_string) =>
-          state.with_team_event(min, poss, event_string).with_latest_score(score)
+        case Model.OtherTeamEvent(min, score, event_string) =>
+          state.with_team_event(min, event_string).with_latest_score(score)
 
-        case Model.OtherOpponentEvent(min, score, poss, event_string) =>
-          state.with_opponent_event(min, poss, event_string).with_latest_score(score)
+        case Model.OtherOpponentEvent(min, score, event_string) =>
+          state.with_opponent_event(min, event_string).with_latest_score(score)
 
         case Model.GameBreakEvent(min) =>
           val completed_curr = complete_lineup(state.curr, state.prev, min)
@@ -431,18 +431,18 @@ object ExtractorUtils {
           )
         )
       }
-      def with_team_event(min: Double, poss: Int, event_string: String): LineupBuildingState =
+      def with_team_event(min: Double, event_string: String): LineupBuildingState =
         copy(
           curr = curr.copy(
             end_min = min,
-            raw_game_events = LineupEvent.RawGameEvent.team(event_string, poss) :: curr.raw_game_events
+            raw_game_events = LineupEvent.RawGameEvent.team(event_string, min) :: curr.raw_game_events
           )
         )
-      def with_opponent_event(min: Double, poss: Int, event_string: String): LineupBuildingState =
+      def with_opponent_event(min: Double, event_string: String): LineupBuildingState =
         copy(
           curr = curr.copy(
             end_min = min,
-            raw_game_events = LineupEvent.RawGameEvent.opponent(event_string, poss) :: curr.raw_game_events
+            raw_game_events = LineupEvent.RawGameEvent.opponent(event_string, min) :: curr.raw_game_events
           )
         )
     }
@@ -458,10 +458,6 @@ object ExtractorUtils {
     sealed trait MiscGameEvent extends PlayByPlayEvent {
       /** The raw event string */
       def event_string: String
-      /** The possession number, once calculated */
-      def poss: Int
-      /** Updates the possession count */
-      def with_poss(new_poss: Int): MiscGameEvent
       /** The current score */
       def score: Game.Score
     }
@@ -477,13 +473,11 @@ object ExtractorUtils {
     case class SubOutEvent(min: Double, player_name: String) extends SubEvent {
       def with_min(new_min: Double): SubOutEvent = copy(min = new_min)
     }
-    case class OtherTeamEvent(min: Double, score: Game.Score, poss: Int, event_string: String) extends MiscGameEvent {
+    case class OtherTeamEvent(min: Double, score: Game.Score, event_string: String) extends MiscGameEvent {
       def with_min(new_min: Double): OtherTeamEvent = copy(min = new_min)
-      def with_poss(new_poss: Int): OtherTeamEvent = copy(poss = new_poss)
     }
-    case class OtherOpponentEvent(min: Double, score: Game.Score, poss: Int, event_string: String) extends MiscGameEvent {
+    case class OtherOpponentEvent(min: Double, score: Game.Score, event_string: String) extends MiscGameEvent {
       def with_min(new_min: Double): OtherOpponentEvent = copy(min = new_min)
-      def with_poss(new_poss: Int): OtherOpponentEvent = copy(poss = new_poss)
     }
     case class GameBreakEvent(min: Double) extends MiscGameBreak {
       def with_min(new_min: Double): GameBreakEvent = copy(min = new_min)

--- a/src/main/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/ExtractorUtils.scala
+++ b/src/main/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/ExtractorUtils.scala
@@ -356,8 +356,6 @@ object ExtractorUtils {
     val new_player_list =
       (curr_players -- curr_players_out.keySet ++ curr_players_in).values.toList
 
-    val (team_possessions, opponent_possessions) = PossessionUtils.sum_possessions(curr, prevs)
-
     curr.copy(
       end_min = min,
       duration_mins = min - curr.start_min,
@@ -366,11 +364,11 @@ object ExtractorUtils {
       ),
       team_stats = curr.team_stats.copy(
         num_events = curr.raw_game_events.filter(_.team.isDefined).size,
-        num_possessions = team_possessions
+        num_possessions = 0 //(calculate later)
       ),
       opponent_stats = curr.opponent_stats.copy(
         num_events = curr.raw_game_events.filter(_.opponent.isDefined).size, //TODO exclude subs
-        num_possessions = opponent_possessions
+        num_possessions = 0 //(calculate later)
       ),
       lineup_id = build_lineup_id(new_player_list),
       players = new_player_list.sortBy(_.code),

--- a/src/main/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/ExtractorUtils.scala
+++ b/src/main/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/ExtractorUtils.scala
@@ -454,6 +454,8 @@ object ExtractorUtils {
       def poss: Int
       /** Updates the possession count */
       def with_poss(new_poss: Int): MiscGameEvent
+      /** The current score */
+      def score: Game.Score
     }
     sealed trait SubEvent extends PlayByPlayEvent {
       /** The raw or processed substitute name */

--- a/src/main/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/ExtractorUtils.scala
+++ b/src/main/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/ExtractorUtils.scala
@@ -42,7 +42,7 @@ object ExtractorUtils {
       }
 
       event match {
-        case Model.SubInEvent(min, player_name) if state.is_active(min) =>
+        case Model.SubInEvent(min, _, player_name) if state.is_active(min) =>
           val tidier_player_name = tidy_player(player_name)
           val completed_curr = complete_lineup(state.curr, state.prev, min)
           state.copy(
@@ -52,7 +52,7 @@ object ExtractorUtils {
             prev = completed_curr :: state.prev,
             old_format = is_old_format(player_name, state)
           )
-        case Model.SubOutEvent(min, player_name) if state.is_active(min) =>
+        case Model.SubOutEvent(min, _, player_name) if state.is_active(min) =>
           val tidier_player_name = tidy_player(player_name)
           val completed_curr = complete_lineup(state.curr, state.prev, min)
           state.copy(
@@ -62,14 +62,14 @@ object ExtractorUtils {
             prev = completed_curr :: state.prev,
             old_format = is_old_format(player_name, state)
           )
-        case Model.SubInEvent(min, player_name) => // !state.is_active
+        case Model.SubInEvent(min, _, player_name) => // !state.is_active
           // Keep adding sub events
           val tidier_player_name = tidy_player(player_name)
           state.with_player_in(tidier_player_name).copy(
             old_format = is_old_format(player_name, state)
           )
 
-        case Model.SubOutEvent(min, player_name) => // !state.is_active
+        case Model.SubOutEvent(min, _, player_name) => // !state.is_active
           // Keep adding sub events
           val tidier_player_name = tidy_player(player_name)
           state.with_player_out(tidier_player_name).copy(
@@ -82,7 +82,7 @@ object ExtractorUtils {
         case Model.OtherOpponentEvent(min, score, event_string) =>
           state.with_opponent_event(min, event_string).with_latest_score(score)
 
-        case Model.GameBreakEvent(min) =>
+        case Model.GameBreakEvent(min, _) =>
           val completed_curr = complete_lineup(state.curr, state.prev, min)
           val (new_lineup_id, new_players) =
             if (state.old_format.getOrElse(box_lineup.team.year.value < 2018)) {
@@ -97,7 +97,7 @@ object ExtractorUtils {
             ),
             prev = completed_curr :: state.prev
           )
-        case Model.GameEndEvent(min) =>
+        case Model.GameEndEvent(min, _) =>
           state.copy(curr = complete_lineup(state.curr, state.prev, min))
       }
     }
@@ -218,23 +218,66 @@ object ExtractorUtils {
    * (non-sub-events) (sub-events) (non-sub events)
    * where ... all game events that reference players subbed out is in the first group,
    * all game events that reference players subbed in is in the second group, and
-   * if neither of these things holds then events that occur before the first sub
+   * FTs in the same direction as a pre-sub foul go in the same direction
+   * if neither of these things holds then events that occur lower/same score as the first sub
    * live in the first group, everything else lives in the second group
    * Simples!
    * Examples:
    * a) SUB_SET_1; REBOUND_X; SUB_SET_2 .. which should map to:
-   *    SET_SET_1; SUB_SET_2; REBOUND_X unless X is subbed out in one of the sub sets
+   *    REBOUND_X; SET_SET_1; SUB_SET_2 unless X is subbed in in one of the sub sets
+   *                                    OR occurs with a higher score that SUB_SET1
    * b) B FREE THROW; A REBOUND; A ENTERS ... which should map to:
    *    B FREE THROW; A ENTERS; A REBOUND
    * BUT
    * c) A FREE THROW; A LEAVES ... should stay the same
+   *
+   * Actually most of the cases don't involve subs and are FT0related, examples:
+   * (imagine these events come in totally random orders in practice!)
+
+   00:23:10		67-76	Anthony Cowan, foul personal 2freethrow
+   00:23:10	Aaron Jordan, foulon	67-76 <== (sometimes this name is wrong!)
+   00:23:10		67-76	Anthony Cowan, substitution out
+   00:23:10		67-76	Reese Mona, substitution in
+   (lineup break)
+   00:23:10	Aaron Jordan, freethrow 1of2 fastbreak made	67-77
+   00:23:10	Tevian Jones, substitution in	67-77
+   00:23:10	Adonis De La Rosa, substitution out	67-77
+   00:23:10	Aaron Jordan, freethrow 2of2 fastbreak made	67-78
+
+   or:
+   13:45:00		26-41	Aaron Wiggins, 2pt stepbackjumpshot missed
+   ---
+   13:43:00		26-41	Jalen Smith, substitution out
+   13:43:00		26-41	Ricky Lindo Jr., substitution in
+   (opp sub)
+   13:43:00		26-41	Team, rebound offensive team
+   13:43:00		26-41	Darryl Morsell, substitution out
+   13:43:00		26-41	Anthony Cowan, substitution in
+   13:38:00		26-43	Eric Ayala, 2pt drivinglayup 2ndchance;pointsinthepaint made
+   
+   *
    * (protected just to support testing)
    */
   protected [ncaa] def reorder_and_reverse(
     reversed_partial_events: Iterator[Model.PlayByPlayEvent]
   ): List[Model.PlayByPlayEvent] = {
     /** Ensures subs don't enclose plays */
-    def inner_sort(ordered_block: List[Model.PlayByPlayEvent]): List[Model.PlayByPlayEvent] = {
+    def inner_sort(pre_ordered_block: List[Model.PlayByPlayEvent]): List[Model.PlayByPlayEvent] = {
+      // first, order by score to get the weirdest cases out (and rank scoring shots earlier)
+      val ordered_block = pre_ordered_block.sortBy {
+        // events where the score increments live "in between" curr and next scores
+        case ev: Model.MiscGameEvent if
+          EventUtils.ParseFreeThrowMade.unapply(ev.event_string).nonEmpty ||
+          EventUtils.ParseShotMade.unapply(ev.event_string).nonEmpty
+        =>
+          (ev.score.scored, ev.score.allowed, 0)
+
+        // (subs live at the end)
+        case ev: Model.SubOutEvent => (ev.score.scored, ev.score.allowed, 10)
+        case ev: Model.SubInEvent => (ev.score.scored, ev.score.allowed, 10)
+
+        case ev => (ev.score.scored, ev.score.allowed, 1)
+      }
       val subs = (ordered_block.collect {
         case ev: Model.SubEvent => ev
       })
@@ -246,7 +289,8 @@ object ExtractorUtils {
           case _ => false
         }
         case class State(
-          seen_sub: Boolean,
+          sub_score: Option[Game.Score],
+          direction_team: Option[Boolean],
           group_1: List[Model.PlayByPlayEvent],
           group_2: List[Model.PlayByPlayEvent]
         ) {
@@ -256,30 +300,57 @@ object ExtractorUtils {
           }
         }
         /** Does the event reference a player who was subbed (in or out as param)? */
-        def event_refs_subbed_player(ev: Model.MiscGameEvent, in_or_out: List[Model.SubEvent]): Boolean = {
+        def event_refs_player(ev: Model.MiscGameEvent, in_or_out: List[Model.SubEvent]): Boolean = {
           //(don't need to worry about case because these names are all extracted from the same PbP source)
           in_or_out.exists { candidate =>
             ev.event_string.contains(candidate.player_name)
           }
         }
-        val starting_state = State(seen_sub = false, Nil, Nil)
+        val starting_state = State(None, None, Nil, Nil)
         /** Adds to either the "pre-sub" list of the "post-sub" one based on state */
         def add_to_state(state: State, ev: Model.PlayByPlayEvent) = {
-          if (state.seen_sub) {
+          def score_gt(s1: Game.Score, s2: Game.Score): Boolean = {
+            import scala.math.Ordering.Implicits._
+            Game.Score.unapply(s1).get > Game.Score.unapply(s2).get
+          }
+          if (state.sub_score.exists(score => score_gt(ev.score, score))) {
             state.copy(group_2 = ev :: state.group_2)
           } else {
-            state.copy(group_1 = ev :: state.group_1)
+            state.copy( //(log direction of pre-sub action, so can pull FTs from after the sub in)
+              direction_team = Option(ev).collect {
+                case ev: Model.MiscGameEvent
+                  if EventUtils.ParseFreeThrowEvent.unapply(ev.event_string).nonEmpty ||
+                      EventUtils.ParseShotMade.unapply(ev.event_string).nonEmpty ||
+                      EventUtils.ParseFoulInfo.unapply(ev.event_string).nonEmpty
+                  =>
+                    ev.is_team_dir
+
+                case ev: Model.MiscGameEvent
+                  if EventUtils.ParseTechnicalFoul.unapply(ev.event_string).nonEmpty ||
+                      EventUtils.ParsePersonalFoul.unapply(ev.event_string).nonEmpty
+                  =>
+                    !ev.is_team_dir
+              }.orElse(state.direction_team),
+              group_1 = ev :: state.group_1
+            )
           }
         }
         (ordered_block.foldLeft(starting_state) { (state, next_event) =>
           next_event match {
             case ev: Model.SubEvent => //(already added to "subs")
-              state.copy(seen_sub = true)
+              state.copy(sub_score = Some(ev.score))
+
+            // Always put FTs tied to pre-sub events in the first group
+            case ev: Model.MiscGameEvent
+              if EventUtils.ParseFreeThrowAttempt.unapply(ev.event_string).nonEmpty &&
+                state.direction_team.exists(_ == ev.is_team_dir)
+            =>
+              state.copy(group_1 = ev :: state.group_1)
 
             case ev: Model.OtherTeamEvent =>
-              if (event_refs_subbed_player(ev, sub_ins)) {
+              if (event_refs_player(ev, sub_ins)) {
                 state.copy(group_2 = ev :: state.group_2)
-              } else if (event_refs_subbed_player(ev, sub_outs)) {
+              } else if (event_refs_player(ev, sub_outs)) {
                 state.copy(group_1 = ev :: state.group_1)
               } else {
                 add_to_state(state, ev)
@@ -453,13 +524,16 @@ object ExtractorUtils {
       def min: Double
       /** Update the minute (eg to switch from descending to ascending internal)*/
       def with_min(new_min: Double): PlayByPlayEvent
+      /** The current score */
+      def score: Game.Score
     }
     // Wildcard events
     sealed trait MiscGameEvent extends PlayByPlayEvent {
       /** The raw event string */
       def event_string: String
-      /** The current score */
-      def score: Game.Score
+
+      /** Whether the event is in the team direction */
+      def is_team_dir: Boolean
     }
     sealed trait SubEvent extends PlayByPlayEvent {
       /** The raw or processed substitute name */
@@ -467,22 +541,24 @@ object ExtractorUtils {
     }
     sealed trait MiscGameBreak extends PlayByPlayEvent
     // Concrete
-    case class SubInEvent(min: Double, player_name: String) extends SubEvent {
+    case class SubInEvent(min: Double, score: Game.Score, player_name: String) extends SubEvent {
       def with_min(new_min: Double): SubInEvent = copy(min = new_min)
     }
-    case class SubOutEvent(min: Double, player_name: String) extends SubEvent {
+    case class SubOutEvent(min: Double, score: Game.Score, player_name: String) extends SubEvent {
       def with_min(new_min: Double): SubOutEvent = copy(min = new_min)
     }
     case class OtherTeamEvent(min: Double, score: Game.Score, event_string: String) extends MiscGameEvent {
       def with_min(new_min: Double): OtherTeamEvent = copy(min = new_min)
+      def is_team_dir: Boolean = true
     }
     case class OtherOpponentEvent(min: Double, score: Game.Score, event_string: String) extends MiscGameEvent {
       def with_min(new_min: Double): OtherOpponentEvent = copy(min = new_min)
+      def is_team_dir: Boolean = false
     }
-    case class GameBreakEvent(min: Double) extends MiscGameBreak {
+    case class GameBreakEvent(min: Double, score: Game.Score) extends MiscGameBreak {
       def with_min(new_min: Double): GameBreakEvent = copy(min = new_min)
     }
-    case class GameEndEvent(min: Double) extends MiscGameBreak {
+    case class GameEndEvent(min: Double, score: Game.Score) extends MiscGameBreak {
       def with_min(new_min: Double): GameEndEvent = copy(min = new_min)
     }
   }

--- a/src/main/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/LineupUtils.scala
+++ b/src/main/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/LineupUtils.scala
@@ -6,7 +6,6 @@ import org.piggottfamily.cbb_explorer.models.ncaa._
 
 /** Utilities related to building up the lineup stats */
 trait LineupUtils {
-  import StateUtils.StateTypes._
   import ExtractorUtils._
 
   /** Useful scriptlet for checking results
@@ -29,7 +28,6 @@ val (team_possessions, opp_possessions, proc_events, adjust_prev_lineup) =
   {
     val scored = lineup.score_info.end.scored - lineup.score_info.start.scored
     val allowed = lineup.score_info.end.allowed - lineup.score_info.start.allowed
-    val last_game_event =  prev_lineup.flatMap(_.raw_game_events.lastOption)
 
     lineup.copy(
       team_stats = lineup.team_stats.copy(
@@ -43,9 +41,8 @@ val (team_possessions, opp_possessions, proc_events, adjust_prev_lineup) =
         num_possessions = 0, //TODO as above
         pts = allowed,
         plus_minus = allowed - scored
-      ),
-      raw_game_events = proc_events
-    ) -> adjusted_prev_lineup
+      )
+    )
   }
 
   /** There is a weird bug that has happened one time where the scores got swapped */
@@ -87,223 +84,5 @@ val (team_possessions, opp_possessions, proc_events, adjust_prev_lineup) =
       case _ => lineup //(we're good, nothing to do)
     }
   }
-
-  /** Returns team and opponent possessions based on the raw event data */
-  def calculate_possessions(
-    raw_events: Seq[LineupEvent.RawGameEvent]
-  ): List[LineupEvent.RawGameEvent] =
-  {
-    // Lots of data modelling:
-
-    /** Which team is in possession */
-    object Direction extends Enumeration {
-      val Init, Team, Opponent = Value
-
-      /** Switch direction */
-      def opposite(dir: Direction.Value): Direction.Value = dir match {
-        case Direction.Init => dir
-        case Direction.Team = Direction.Opponent
-        case Direction.Opponent = Direction.Team
-      }
-    }
-    /** State for building possession events */
-    case class PossState(
-      team: Int, opponent: Int,
-      direction: Direction.Value,
-      possession_unclear: Boolean
-    )
-    object PossState {
-      /** Starting state */
-      def init: PossState  = PossState(
-        0, 0, Direction.Init, false
-      )
-    }
-
-    case class ConcurrentClump(evs: List[LineupEvent.RawGameEvent])
-
-    sealed trait PossessionStatus
-    case object PossessionUnclear extends PossessionStatus
-    case object PossessionContinues extends PossessionStatus
-    case class PossessionEnd(last_clump: Boolean = false) extends PossessionStatus
-
-    case class PossessionEvent(dir: Direction.Value) {
-      /** The team in possession */
-      object AttackingTeam {
-        def unapply(x: RawGameEvent): Option[String] = dir match {
-          case Direction.Team => x.team
-          case Direction.Opponent => x.opponent
-          case _ => None
-        }
-      }
-      /** The team not in possession */
-      object DefendingTeam {
-        def unapply(x: RawGameEvent): Option[String] = dir match {
-          case Direction.Team => x.opponent
-          case Direction.Opponent => x.opponent
-          case _ => None
-        }
-      }
-    }
-
-    /** Adds possession count to raw event */
-    def enrich(state: PossState, ev: LineupEvent.RawGameEvent): LineupEvent.RawGameEvent = {
-      val enriched_event = ev.copy(
-        team_possession = if (state.direction == Direction.Team) Some(state.team) else None,
-        opponent_possession = if (state.direction == Direction.Opponent) Some(state.opponent) else None
-      )
-      enriched_event
-    }
-
-    /** Figure out who has possession to start the game */
-    def first_possession_status(evs: List[LineupEvent.RawGameEvent]): Option[Direction.Value] = {
-      evs.collect {
-        case RawGameEvent.Team(EventUtils.ParseCommonOffensiveEvent(_)) =>
-          Some(Direction.Team)
-        case RawGameEvent.Team(EventUtils.ParseCommonDefensiveEvent(_)) =>
-          Some(Direction.Opponent)
-        case RawGameEvent.Opponent(EventUtils.ParseCommonOffensiveEvent(_)) =>
-          Some(Direction.Opponent)
-        case RawGameEvent.Opponent(EventUtils.ParseCommonDefensiveEvent(_)) =>
-          Some(Direction.Team)
-      }.headOption
-    }
-
-    /** Process the events within a concurrent clump to see if the possession is changing/has changed */
-    def clump_possession_status(
-      state: PossState,
-      evs: List[LineupEvent.RawGameEvent]
-    ): PossessionStatus =
-    {
-      val dir = state.direction
-      /** This is the highest prio .. if the defending team rebounds it, they now have possession */
-      def defensive_rebound(evs: List[LineupEvent.RawGameEvent]): Boolean = {
-        evs.collect {
-          case PossessionEvent(dir).DefendingTeam(EventUtils.Rebound(_)) =>
-        }.nonEmpty
-      }
-
-      def offensive_rebound(evs: List[LineupEvent.RawGameEvent]): Boolean = {
-        evs.collect {
-          case PossessionEvent(dir).AttackingTeam(EventUtils.Rebound(_)) =>
-        }.nonEmpty
-      }
-
-      /** Offensive turnover */
-      def offensive_turnover(evs: List[LineupEvent.RawGameEvent]): Boolean = {
-        evs.collect {
-          case PossessionEvent(dir).AttackingTeam(EventUtils.Turnover(_)) =>
-        }.nonEmpty
-      }
-
-      /** Made shot and missed the and one ... need to wait for DRB */
-      def made_shot_and_missed_and_one(evs: List[LineupEvent.RawGameEvent]): Boolean = {
-        made_shot(evs) &&
-        ev.collect {
-          case PossessionEvent(dir).AttackingTeam(EventUtils.ParseFreeThrowMissed(_)) =>
-        }.nonEmpty
-      }
-
-      /** Made shot (use order of clauses to ensure there was no missed and-1) */
-      def made_shot(evs: List[LineupEvent.RawGameEvent]): Boolean = {
-        evs.collect {
-          case PossessionEvent(dir).AttackingTeam(EventUtils.ParseShotMade(_)) =>
-        }.nonEmpty
-      }
-
-      /** Took free throws and hit at least one of them */
-      def fts_some_made(evs: List[LineupEvent.RawGameEvent]): Boolean = {
-        evs.collect {
-          case PossessionEvent(dir).ParseFreeThrowMade(EventUtils.ParseShotMade(_)) =>
-        }.nonEmpty
-      }
-
-      /** Took free throws and missed at least one of them */
-      def fts_some_missed(evs: List[LineupEvent.RawGameEvent]): Boolean = {
-        evs.collect {
-          case PossessionEvent(dir).ParseFreeThrowMade(EventUtils.ParseShotMissed(_)) =>
-        }.nonEmpty
-      }
-
-      //TODO: end of period
-
-      //TODO: error on inconsistencies rather than silently give the wrong possession count
-
-      evs match {
-        case _ if defensive_rebound(evs) => PossessionEnd(last_clump = true)
-        case _ if state.possession_unclear && !offensive_rebound(evs) => PossessionEnd(last_clump = true)
-
-        case _ if offensive_turnover(evs) => PossessionEnd()
-        case _ if made_shot_and_missed_and_one(evs) => PossessionContinues //(wait for the rebound)
-        case _ if made_shot(evs) => PossessionEnd()
-
-        case _ if fts_some_missed(evs) && fts_some_made(evs) => PossessionUnclear
-          //(the problem here is that with legacy data we don't know if the last one missed ...
-          // what happens is if there's no rebound on either side then possession changes
-          // if there's a DRB possession changes are per usual, and otherwise (==ORB) possession continues)
-
-        case _ if fts_some_missed(evs) => PossessionContinues //(all FTs missed => last FT missed => wait for the rebound)
-        case _ if fts_some_made(evs) => PossessionEnd()
-        case _ => PossessionContinues
-      }
-    }
-
-    /** Sort out state if possession changes */
-    def switch_state(state: PossState): PossState = {
-      if (state.direction == Direction.Team) {
-        state.copy(
-          opponent = state.opponent + 1, direction = Direction.Opponent,
-          possession_unclear = false
-        )
-      } else { //(must be Opponent, not Init, by construction)
-        state.copy(
-          team = state.team + 1, direction = Direction.Team,
-          possession_unclear = false
-        )
-      }
-    }
-
-    /** Updates the state and enriches the events with poss number based on incoming clump */
-    def handle_clump(
-      state: PossState, evs: List[LineupEvent.RawGameEvent]
-    ): (PossState, List[LineupEvent.RawGameEvent]) = clump_possession_status(state, evs) match {
-      case PossessionEnd(true) =>
-        val new_state = switch_state(state)
-        handle_clump(new_state, evs) //(can't recurse more than once by construction)
-      case PossessionEnd(false) =>
-        val new_state = switch_state(state)
-        (new_state, evs.map(ev => enrich(new_state, ev)))
-      case PossessionUnclear =>
-        (state.copy(possession_unclear = true), evs.map(ev => enrich(state, ev)))
-      case PossessionContinues =>
-        (state.copy(possession_unclear = false), evs.map(ev => enrich(state, ev)))
-    }
-
-    //TODO: clumper
-    val clumped_events = raw_events.map(ev => ConcurrentClump(List(ev)))
-    (StateUtils.foldLeft(clumped_events, PossState.init, classOf[LineupEvent.RawGameEvent]) {
-
-      case StateEvent.Next(ctx, state, ConcurrentClump(evs)) if state.direction == Direction.Init =>
-        // First state, who has the first possession?
-        first_possession_status(evs) match {
-          case Some(dir) =>
-            val new_state = switch_state(state.copy(direction = Direction.opposite(dir)))
-            handle_clump(new_state, evs)
-          case _ =>
-            (state, ev) //(do nothing, wait for next clump)
-        }
-
-      case StateEvent.Next(ctx, state, ConcurrentClump(evs)) => // Standard processing
-        val (new_state, enriched_evs) = handle_clump(state, evs)
-        ctx.stateChange(new_state, enriched_evs)
-
-      case StateEvent.Complete(ctx, _) => //(no additional processing when element list complete)
-        ctx.noChange
-
-    }) match {
-      case FoldStateComplete(_, events) =>
-        events
-    }
-
-  } //(end calculate_possessions)
 }
 object LineupUtils extends LineupUtils

--- a/src/main/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/LineupUtils.scala
+++ b/src/main/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/LineupUtils.scala
@@ -8,21 +8,6 @@ import org.piggottfamily.cbb_explorer.models.ncaa._
 trait LineupUtils {
   import ExtractorUtils._
 
-  /** Useful scriptlet for checking results
-  // Show results
-  l.groupBy(t => (t.opponent, t.location_type)).mapValues(
-    _.foldLeft((0,0))
-    { (acc, v) => (acc._1 + v.team_stats.num_possessions,acc._2 + v.opponent_stats.num_possessions) }
-  )
-  // Compare to previous results
-  (x1 zip x2).map { case (k, v) => k._1 -> (k._2._1 - v._2._1, k._2._2 - v._2._2) }
-  */
-
-/** TODO`
-val (team_possessions, opp_possessions, proc_events, adjust_prev_lineup) =
-  calculate_possessions(lineup.raw_game_events, last_game_event)
-*/
-
   /** TODO build the stats from the game events */
   def enrich_lineup(lineup: LineupEvent): LineupEvent =
   {
@@ -31,14 +16,10 @@ val (team_possessions, opp_possessions, proc_events, adjust_prev_lineup) =
 
     lineup.copy(
       team_stats = lineup.team_stats.copy(
-        num_events = lineup.raw_game_events.filter(_.team.isDefined).size,
-        num_possessions = 0, //TODO: enrich based on raw events
         pts = scored,
         plus_minus = scored - allowed
       ),
       opponent_stats = lineup.opponent_stats.copy(
-        num_events = lineup.raw_game_events.filter(_.opponent.isDefined).size, //TODO exclude subs
-        num_possessions = 0, //TODO as above
         pts = allowed,
         plus_minus = allowed - scored
       )

--- a/src/main/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/PlayByPlayParser.scala
+++ b/src/main/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/PlayByPlayParser.scala
@@ -80,13 +80,12 @@ trait PlayByPlayParser {
     }.map { events =>
       val processed_events = events.map(enrich_lineup _)
 
-      // Calculate lineups:
-//TODO      
-      PossessionUtils.calculate_possessions(
-        processed_events.flatMap(_.raw_game_events), Nil
+      // Calculate possessions per lineup
+      var lineups_with_poss = PossessionUtils.calculate_possessions(
+        processed_events
       )
 
-      processed_events.partition(e => validate_lineup(e, player_codes).isEmpty)
+      lineups_with_poss.partition(e => validate_lineup(e, player_codes).isEmpty)
     }
   }
 

--- a/src/main/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/PlayByPlayParser.scala
+++ b/src/main/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/PlayByPlayParser.scala
@@ -72,14 +72,15 @@ trait PlayByPlayParser {
     val player_codes = box_lineup.players.map(_.code).toSet
 
     parse_game_events(filename, in, box_lineup.team.team).map { reversed_events =>
-      val reversed_events_with_poss = PossessionUtils.calculate_possessions(
+//TODO: just here for display during testing      
+      PossessionUtils.calculate_possessions(
         reversed_events.reverse //(enrich with possessions)
       ).reverse
 
       // There is a weird bug that has happened one time where the scores got swapped
       // So we'll identify and fix this case
       fix_possible_score_swap_bug(
-        build_partial_lineup_list(reversed_events_with_poss.toIterator, box_lineup), box_lineup
+        build_partial_lineup_list(reversed_events.toIterator, box_lineup), box_lineup
       )
     }.map { events =>
       val processed_events = events.map(enrich_lineup _)

--- a/src/main/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/PlayByPlayParser.scala
+++ b/src/main/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/PlayByPlayParser.scala
@@ -72,10 +72,14 @@ trait PlayByPlayParser {
     val player_codes = box_lineup.players.map(_.code).toSet
 
     parse_game_events(filename, in, box_lineup.team.team).map { reversed_events =>
+      val reversed_events_with_poss = PossessionUtils.calculate_possessions(
+        reversed_events.reverse //(enrich with possessions)
+      ).reverse
+
       // There is a weird bug that has happened one time where the scores got swapped
       // So we'll identify and fix this case
       fix_possible_score_swap_bug(
-        build_partial_lineup_list(reversed_events.toIterator, box_lineup), box_lineup
+        build_partial_lineup_list(reversed_events_with_poss.toIterator, box_lineup), box_lineup
       )
     }.map { events =>
       val processed_events = events.map(enrich_lineup _)

--- a/src/main/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/PossessionUtils.scala
+++ b/src/main/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/PossessionUtils.scala
@@ -3,11 +3,54 @@ package org.piggottfamily.cbb_explorer.utils.parsers.ncaa
 import org.piggottfamily.utils.StateUtils
 import org.piggottfamily.cbb_explorer.models._
 import org.piggottfamily.cbb_explorer.models.ncaa._
+import scala.util.Try
 
 /** Utilities related to calculation possession from raw game events */
 trait PossessionUtils {
   import ExtractorUtils._
   import StateUtils.StateTypes._
+
+  /** Useful scriptlet for checking results
+  // Show results
+  l.groupBy(t => (t.opponent, t.location_type)).mapValues(
+    _.foldLeft((0,0))
+    { (acc, v) => (acc._1 + v.team_stats.num_possessions,acc._2 + v.opponent_stats.num_possessions) }
+  )
+  //Or:
+  l.groupBy(t => (t.opponent, t.location_type)).mapValues(
+    _.flatMap(_.raw_game_events).reverse.flatMap(ev => ev.team_possession.orElse(ev.opponent_possession)).headOption
+  )
+  // Compare to previous results
+  (x1 zip x2).map { case (k, v) => k._1 -> (k._2._1 - v._2._1, k._2._2 - v._2._2) }
+  */
+
+  /**
+TODO current batch of issues:
+1] turnover -> steal pair isn't concurrent :/
+2] not sure yet
+
+ (del->umd)RawGameEvent(Some("17:42,5-0,FERNANDO,BRUNO Defensive Rebound"), None, Some(5), None),
+
+ (umd->del)RawGameEvent(Some("17:32,5-0,FERNANDO,BRUNO Turnover"), None, Some(6), None),
+
+ RawGameEvent(None, Some("17:31,5-0, MISSING_POSSESSION_END"), None, Some(6)),
+ (del-!->umd->umd)RawGameEvent(None, Some("17:31,5-0,CARTER JR.,JOHN Steal"), None, Some(7)),
+
+ RawGameEvent(Some("17:27,5-0, MISSING_POSSESSION_END"), None, Some(7), None),
+ RawGameEvent(None, Some("17:27,5-0,CARTER JR.,JOHN missed Two Point Jumper"), None, Some(7)),
+ RawGameEvent(Some("17:27,5-0,FERNANDO,BRUNO Defensive Rebound"), None, Some(7), None),
+--(umd)-->
+RawGameEvent(Some("17:27,5-0, MISSING_POSSESSION_END"), None, Some(7), None),
+   (umd-!->del->umd)RawGameEvent(Some("17:27,5-0,FERNANDO,BRUNO Defensive Rebound"), None, Some(7), None),
+//(should be another missed possession here?! unless my concurrent list is in the wronf order)
+   (umd-!->del->del)RawGameEvent(None, Some("17:27,5-0,CARTER JR.,JOHN missed Two Point Jumper"), None, Some(7)),
+
+ RawGameEvent(Some("17:20,5-0,SMITH,JALEN missed Three Point Jumper"), None, Some(8), None),
+
+TODO maybe have descriptive (steal/block/foulon) vs actionable (made/missed/rebound)
+and then if the descriptive one is wrong, we just enrich it with the previous state?
+
+*/
 
   // Lots of data modelling:
 
@@ -26,15 +69,12 @@ trait PossessionUtils {
   protected case class PossState(
     team: Int, opponent: Int,
     direction: Direction.Value,
-    possession_arrow: Direction.Value, //(who gets possession next game break)
-    status: PossState.Status.Value
-  ) {
-    def broken: Boolean = status == PossState.Status.Error
-  }
+    possession_arrow: Direction.Value //(who gets possession next game break)
+  )
   protected object PossState {
     /** Starting state */
     def init: PossState  = PossState(
-      0, 0, Direction.Init, Direction.Init, Status.Normal
+      0, 0, Direction.Init, Direction.Init
     )
     /** Handles concurrency issues with the input data */
     case class ConcurrencyState(
@@ -44,9 +84,6 @@ trait PossessionUtils {
       /** Starting state */
       def init: ConcurrencyState = ConcurrencyState(-1.0)
     }
-    object Status extends Enumeration {
-      val Normal, Error = Value
-    }
   }
 
   protected case class ConcurrentClump(evs: List[Model.PlayByPlayEvent])
@@ -55,8 +92,7 @@ trait PossessionUtils {
   protected case object PossessionArrowSwitch extends PossessionStatus
   protected case object PossessionError extends PossessionStatus
   protected case object PossessionContinues extends PossessionStatus
-  /** compound_clump means that might have O and D possessions in the same clump */
-  protected case class PossessionEnd(compound_clump: Boolean = false) extends PossessionStatus
+  protected case object PossessionEnd extends PossessionStatus
 
   protected case class PossessionEvent(dir: Direction.Value) {
     /** The team in possession */
@@ -78,7 +114,7 @@ trait PossessionUtils {
   }
 
   /** We generate this if the possession calcuations go wrong */
-  val ERROR_EVENT = Model.OtherTeamEvent(0.0, Game.Score(0, 0), 0, "00:00,0-0,POSSESSION_STATE_ERROR")
+  val error_event_string = "MISSING_POSSESSION_END"
 
   /** Util methods */
 
@@ -104,10 +140,79 @@ trait PossessionUtils {
   protected def rearrange_concurrent_event(
     s: PossState, cs: PossState.ConcurrencyState, reverse_clump: List[ConcurrentClump]
   ): List[ConcurrentClump] = {
-    List(ConcurrentClump(
+    val raw_list =
       reverse_clump.foldLeft(List[Model.PlayByPlayEvent]()) { (acc, v) => v.evs ++ acc } //(re-reverses it)
-    ))
+
+    // In practice you can have possessions in both directions with concurrent clumps
+    // This is hard to handle. For now we'll support 1 in each direction
+    //TODO(support more)
+    // By splitting the clump into (at most) 2, 1 for each direction based on analyzing the
+    // event type (and using the prev/next if the event isn't clearly in one direction or the other)
+
+    case class InClumpState(
+      start: List[Model.PlayByPlayEvent], //these are consistent with the current direction
+      end: List[Model.PlayByPlayEvent], //these are consistent with the switched direction
+      prev: Direction.Value)
+
+    val current_dir = s.direction
+    val next_dir = Direction.opposite(current_dir)
+
+    val attackingTeam = PossessionEvent(current_dir).AttackingTeam
+    val defendingTeam = PossessionEvent(current_dir).DefendingTeam
+
+    def get_direction(ev: Model.PlayByPlayEvent): Direction.Value = ev match {
+      case attackingTeam(EventUtils.ParseCommonOffensiveEvent(_)) =>
+        current_dir
+      case defendingTeam(EventUtils.ParseCommonDefensiveEvent(_)) =>
+        current_dir
+      case defendingTeam(EventUtils.ParseCommonOffensiveEvent(_)) =>
+        next_dir
+      case attackingTeam(EventUtils.ParseCommonDefensiveEvent(_)) =>
+        next_dir
+      case _ => Direction.Init
+    }
+
+    val InClumpState(start_evs, end_evs, _) =
+      raw_list.foldLeft(InClumpState(Nil, Nil, Direction.Init)) { (state, ev) =>
+        get_direction(ev) match {
+          // Known direction
+          case `current_dir` =>
+            state.copy(start = ev :: state.start, prev = current_dir)
+          case `next_dir` =>
+            state.copy(end = ev :: state.end, prev = next_dir)
+
+          // Unknown direction, can infer from previous:
+          case _ if state.prev == current_dir =>
+            state.copy(start = ev :: state.start)
+          case _ if state.prev == next_dir =>
+            state.copy(end = ev :: state.end)
+
+          // Unknown direction, no previous .. will fetch from next:
+          case _ =>
+            raw_list
+              .toStream.map(get_direction)
+              .filter(_ != Direction.Init)
+              .headOption match {
+                case Some(`current_dir`) =>
+                  state.copy(start = ev :: state.start, prev = current_dir)
+                case Some(_) => //(next dir)
+                  state.copy(end = ev :: state.end, prev = next_dir)
+                case None => //(default to current direction)
+                  state.copy(start = ev :: state.start, prev = current_dir)
+              }
+        }
+      }
+
+    List(
+      ConcurrentClump(
+        start_evs.reverse
+      ),
+      ConcurrentClump(
+        end_evs.reverse
+      )
+    ).filter(_.evs.nonEmpty)
   }
+//TODO: to test
 
   /** Manages splitting stream into concurrent chunks and then combining them */
   protected val concurrent_event_handler = Clumper(
@@ -119,6 +224,12 @@ trait PossessionUtils {
   /** Figure out who has possession to start the game */
   protected def first_possession_status(evs: List[Model.PlayByPlayEvent]): Option[Direction.Value] = {
     evs.collect {
+      // Take advantage of new format
+      case Model.OtherTeamEvent(_, _, _, EventUtils.ParseJumpballWon(_)) =>
+        Direction.Team
+      case Model.OtherOpponentEvent(_, _, _, EventUtils.ParseJumpballWon(_)) =>
+        Direction.Opponent
+      // Legacy calcuations:
       case Model.OtherTeamEvent(_, _, _, EventUtils.ParseCommonOffensiveEvent(_)) =>
         Direction.Team
       case Model.OtherTeamEvent(_, _, _, EventUtils.ParseCommonDefensiveEvent(_)) =>
@@ -127,10 +238,15 @@ trait PossessionUtils {
         Direction.Opponent
       case Model.OtherOpponentEvent(_, _, _, EventUtils.ParseCommonDefensiveEvent(_)) =>
         Direction.Team
+      // Note have to ignore fouls since they can be offensive or defensive, will handle that
+      // in some separate logic before the main fold, below
     }.headOption
   }
 
-  /** Process the events within a concurrent clump to see if the possession is changing/has changed */
+  /** Process the events within a concurrent clump to see if the possession is changing/has changed
+   * Note that the clump has been split into "attacking" and "defending" events, so you won't ever
+   * see both in the same clump
+   */
   protected def clump_possession_status(
     state: PossState,
     in_evs: List[Model.PlayByPlayEvent]
@@ -139,9 +255,12 @@ trait PossessionUtils {
     val defendingTeam = PossessionEvent(state.direction).DefendingTeam
     val attackingTeam = PossessionEvent(state.direction).AttackingTeam
 
-    /** Ignore any events that have already been processed */
-    def previously_processed: Model.PlayByPlayEvent => Boolean = {
+    /** Ignore any events that have already been processed, plus timeouts */
+    def to_ignore: Model.PlayByPlayEvent => Boolean = {
       case ev: Model.MiscGameEvent if ev.poss > 0 => true
+      case attackingTeam(EventUtils.ParseTimeout(_)) => true
+      case defendingTeam(EventUtils.ParseTimeout(_)) => true
+        //(timeouts have no bearing on possession)
       case _ => false
     }
 
@@ -151,32 +270,18 @@ trait PossessionUtils {
       case defendingTeam(EventUtils.ParseCommonOffensiveEvent(_)) => ()
     }.nonEmpty
 
-    // A note on rebounding:
-    // Rebounds can be concurrent with missed shots ... for DRBs this is handled by the
-    // high prio of that case (but explains the logic below for assigning different team/offensive
-    // possesion numbers to the different events in the concurrentl clump), for ORBs this needs to
-    // be specifically handled
-    /** Example:
-    13:19:00	Ryan Cline, rebound defensive	8-7
-    13:19:00	Ryan Cline, block	8-7
-    13:19:00		8-7	Darryl Morsell, 2pt drivinglayup blocked missed
-    * And note you can have any of old-attacker/DRB/new-attacker in a single clump, eg
-    * (OA) shot, (OD) foul, (OA) missed, (OD) drb, (OA) foul, (OD) fts, etc -
-    * seems pretty unlikely you'd ever get more than 2 though, so can proceed on that basis
-    * (but note the code that ensures you only look at unenriched events, which prevents
-    *  an infinite recursion in that case ... we _should_ and do error out though)
-    */
-
     /** This is the highest prio .. if the defending team rebounds it, they now have possession
      * (note fouls on the defense following a missed shot/rebound do generate DRB events)
     */
     def defensive_rebound(evs: List[Model.PlayByPlayEvent]): Boolean = evs.collect {
       case defendingTeam(EventUtils.ParseRebound(_)) => ()
+//TODO: deadball rebound as well, I think?
     }.nonEmpty
 
     /** Offensive turnover */
     def offensive_turnover(evs: List[Model.PlayByPlayEvent]): Boolean = evs.collect {
       case attackingTeam(EventUtils.ParseTurnover(_)) => ()
+      case attackingTeam(EventUtils.ParsePersonalFoul(_)) => ()
     }.nonEmpty
 
     /** Made shot and missed the and one ... need to wait for DRB */
@@ -228,22 +333,24 @@ trait PossessionUtils {
         case ev: Model.MiscGameEvent => ev //(exposes .score, needed below)
       }.sortBy(ev => Game.Score.unapply(ev.score)).reverse match { // reverse => highest first
         case attackingTeam(EventUtils.ParseFreeThrowMade(_)) :: _ => //last free throw was made
-          PossessionEnd()
+          PossessionEnd
         case attackingTeam(EventUtils.ParseFreeThrowMissed(_)) :: _ => //last free throw was missed
           PossessionContinues
       }
     }
 
-    in_evs.filterNot(previously_processed) match {
+    in_evs.filterNot(to_ignore) match {
       case evs if end_of_period(evs) => PossessionArrowSwitch
 
-      case evs if defensive_rebound(evs) => PossessionEnd(compound_clump = true)
+      case evs if defensive_rebound(evs) => PossessionEnd
         // (note: defensive rebounds can be concurrent with misses)
 
       case evs if invalid_possession_state(evs) => PossessionError
         //(it's a bit hard to parse out clumps with DRBs so we'll ignore them for invalid state checks)
 
-      case evs if offensive_turnover(evs) => PossessionEnd()
+      case evs if offensive_turnover(evs) => PossessionEnd
+        //(if we see offensive moves from both teams in the same clump that's OK if there's
+        // a possession change in that clump)
 
       case evs if technical_foul_defense(evs) => PossessionContinues
         //(if the defending team is called for a technical, the offensive team will get the ball back,
@@ -252,14 +359,38 @@ trait PossessionUtils {
 
       case evs if made_shot(evs) && missed_and_one(evs) => PossessionContinues //(wait for the rebound)
         //(any free throws must be an and-1 because technical fouls are handled above)
-      case evs if made_shot(evs) => PossessionEnd() //(no and-1 because of order)
+      case evs if made_shot(evs) => PossessionEnd //(no and-1 because of order)
 
       case evs if fts_some_missed(evs) => handle_missed_freethrows(evs) //untangle what happened
-      case evs if fts_some_made(evs) => PossessionEnd() //(none missed because of order)
+      case evs if fts_some_made(evs) => PossessionEnd //(none missed because of order)
 
       case _ => PossessionContinues
     }
   }
+
+  /** Calculate the possession counts within a lineup */
+  def sum_possessions(curr: LineupEvent, prevs: List[LineupEvent]): (Int, Int) = {
+    def team_or_oppo_calc(poss_getter: LineupEvent.RawGameEvent => List[Int]): Int = {
+      val max_poss = Try(Some(curr.raw_game_events.flatMap(poss_getter).max)).getOrElse(None)
+      val min_poss = Try(Some(curr.raw_game_events.flatMap(poss_getter).min)).getOrElse(None)
+      val prev = prevs.iterator.find(p => p.raw_game_events.flatMap(poss_getter).nonEmpty)
+      //(find most recent previous lineup even with a possession count)
+      val prev_poss = prev.flatMap(
+        p => Try(Some(p.raw_game_events.flatMap(poss_getter).max)).getOrElse(None)
+      )
+      (max_poss, min_poss, prev_poss) match {
+        case (Some(max), Some(min), Some(prev)) if prev == min =>
+          max - min //(min was already counted in the previous lineup)
+        case (Some(max), Some(min), _) => max - min + 1
+        case _ => 0
+      }
+    }
+    (
+      team_or_oppo_calc(_.team_possession.toList),
+      team_or_oppo_calc(_.opponent_possession.toList)
+    )
+  }
+//TODO test
 
   /** Returns team and opponent possessions based on the raw event data */
   def calculate_possessions(
@@ -273,6 +404,7 @@ trait PossessionUtils {
         game_ev.with_poss(state.team)
       case game_ev: Model.MiscGameEvent if (state.direction == Direction.Opponent) && game_ev.poss <= 0 =>
         game_ev.with_poss(state.opponent)
+//TODO: oh wait this isn't right, you can have opponent actions as part of team possession etc
       case _ => ev
     }
 
@@ -280,14 +412,27 @@ trait PossessionUtils {
     def switch_state(state: PossState): PossState = {
       if (state.direction == Direction.Team) {
         state.copy(
-          opponent = state.opponent + 1, direction = Direction.Opponent,
-          status = PossState.Status.Normal
+          opponent = state.opponent + 1, direction = Direction.Opponent
         )
       } else { //(must be Opponent, not Init, by construction)
         state.copy(
-          team = state.team + 1, direction = Direction.Team,
-          status = PossState.Status.Normal
+          team = state.team + 1, direction = Direction.Team
         )
+      }
+    }
+
+    /** If a possession has been missed, create a dummy one to keep the stats correct */
+    def inject_missed_possession(evs: List[Model.PlayByPlayEvent], dir: Direction.Value): Model.PlayByPlayEvent = {
+      val first_game_event = evs.collect {
+        case ev: Model.MiscGameEvent => ev
+      }.headOption.getOrElse(Model.OtherTeamEvent(0.0, Game.Score(0, 0), 0, ""))
+      val event_info = first_game_event.event_string.split(",", 3)
+      val event_time = event_info.lift(0).getOrElse("00:00")
+      val event_score = event_info.lift(1).getOrElse("0-0")
+      val injected_ev_str = s"${event_time},${event_score}, $error_event_string"
+      dir match { //(possession gets injected)
+        case Direction.Team => Model.OtherTeamEvent(first_game_event.min, first_game_event.score, 0, injected_ev_str)
+        case _ => Model.OtherOpponentEvent(first_game_event.min, first_game_event.score, 0, injected_ev_str)
       }
     }
 
@@ -296,10 +441,11 @@ trait PossessionUtils {
       state: PossState, evs: List[Model.PlayByPlayEvent]
     ): (PossState, List[Model.PlayByPlayEvent]) = clump_possession_status(state, evs) match {
 
-      case PossessionError => //latch the error state on, will stop trying to calc possessions
-        val new_state = state.copy(status = PossState.Status.Error)
-        val dummy_event = ERROR_EVENT
-        (new_state, dummy_event :: evs)
+      case PossessionError => //create a missed possession state and carry on
+        val dummy_event = enrich(state, inject_missed_possession(evs, state.direction))
+        val new_state = switch_state(state)
+        //(this can't recurse because each clump is guaranteeed to match one direction only)
+        handle_clump(new_state, dummy_event :: evs)
 
       case PossessionArrowSwitch =>
         val new_state = switch_state(state).copy(
@@ -310,32 +456,22 @@ trait PossessionUtils {
         //get consecutive possessions on either side
         (new_state, evs.map(ev => enrich(state, ev)))
 
-      case PossessionEnd(true) =>
-        val attackingTeam = PossessionEvent(state.direction).AttackingTeam
-        val new_state = switch_state(state)
-        val partially_enriched_evs = evs.map {
-          case ev @ attackingTeam(_) => enrich(state, ev) //(use old state)
-          case ev => ev //(will get enriched next on the recursion below)
-        }
-        handle_clump(new_state, partially_enriched_evs)
-
-      case PossessionEnd(false) =>
+      case PossessionEnd =>
         val attackingTeam = PossessionEvent(state.direction).AttackingTeam
         val new_state = switch_state(state)
         (new_state, evs.map(ev => enrich(state, ev)))
 
       case PossessionContinues =>
-        (state.copy(status = PossState.Status.Normal), evs.map(ev => enrich(state, ev)))
+        (state, evs.map(ev => enrich(state, ev)))
     }
+
+//TODO: before we do anything else, let's check if the first possession is "difficult" and inject
+//dummy events to make life easier if so
 
     val clumped_events = raw_events.map(ev => ConcurrentClump(ev :: Nil))
     (StateUtils.foldLeft(
       clumped_events, PossState.init, classOf[Model.PlayByPlayEvent], concurrent_event_handler
     ) {
-      case StateEvent.Next(ctx, state, ConcurrentClump(evs)) if state.broken =>
-        // An error occurred so we're going to stop calculate possessions for this game
-        ctx.stateChange(state, evs)
-
       case StateEvent.Next(ctx, state, ConcurrentClump(evs)) if state.direction == Direction.Init =>
         // First state, who has the first possession?
         val (new_state, enriched_evs) = first_possession_status(evs) match {

--- a/src/main/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/PossessionUtils.scala
+++ b/src/main/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/PossessionUtils.scala
@@ -47,7 +47,11 @@ trait PossessionUtils {
     }
   }
 
-  protected case class ConcurrentClump(evs: List[LineupEvent.RawGameEvent])
+  protected case class ConcurrentClump(evs: List[LineupEvent.RawGameEvent]) {
+    def min: Option[Double] = evs.headOption.map(_.min)
+    def date_str: Option[String] = evs.headOption.map(_.date_str)
+  }
+  protected case class Last2Clumps(prev: ConcurrentClump, prevprev: ConcurrentClump)
 
   protected case class PossessionEvent(dir: Direction.Value) {
     /** The team in possession */
@@ -100,6 +104,11 @@ trait PossessionUtils {
       s" { +1s=[$ignored_and_ones] offset_techs=[$offsetting_bad_fouls] }"
     }
   }
+
+  /** Decompose the lineup - resulting objects */
+  protected case class LineupDecomp(
+    lineup: LineupEvent, next_lineup: Option[LineupEvent], reverse_prev_lineups: List[LineupEvent]
+  )
 
   /** Util methods */
 
@@ -318,8 +327,8 @@ trait PossessionUtils {
   }
 
   /** Identify concurrent events (easy) */
-  protected def check_for_concurrent_event(
-    ev: Clumper.Event[PossState, PossState.ConcurrencyState, ConcurrentClump]
+  protected def check_for_concurrent_event[S](
+    ev: Clumper.Event[S, PossState.ConcurrencyState, ConcurrentClump]
   ): (PossState.ConcurrencyState, Boolean) = ev match {
     case Clumper.Event(_, cs, Nil, ConcurrentClump(ev :: _)) =>
       //(first event always gens a clump, possibly of size 1)
@@ -338,8 +347,8 @@ trait PossessionUtils {
   }
 
   /** Aggregates all concurrent clumps of 1 event into a single clump of many events */
-  protected def rearrange_concurrent_event(
-    s: PossState, cs: PossState.ConcurrencyState, reverse_clump: List[ConcurrentClump]
+  protected def rearrange_concurrent_event[S](
+    s: S, cs: PossState.ConcurrencyState, reverse_clump: List[ConcurrentClump]
   ): List[ConcurrentClump] = {
     val raw_list =
       reverse_clump.foldLeft(List[LineupEvent.RawGameEvent]()) { (acc, v) => v.evs ++ acc } //(re-reverses it)
@@ -349,29 +358,130 @@ trait PossessionUtils {
   }
 
   /** Manages splitting stream into concurrent chunks and then combining them */
-  protected val concurrent_event_handler = Clumper(
+  protected def concurrent_event_handler[S] = Clumper(
     PossState.ConcurrencyState.init,
-    check_for_concurrent_event _,
-    rearrange_concurrent_event _
+    check_for_concurrent_event[S] _,
+    rearrange_concurrent_event[S] _
   )
 
-  /** Returns team and opponent possessions based on the raw event data */
+  /** Debug flag */
+  protected val show_end_of_raw_calcs = false
+  protected val show_end_of_lineup_calcs = true
+
+  /** Debug util */
+  protected def summarize_state(label: String, state: PossState): Unit = {
+    println(s"--------$label------------")
+    println(s"[${state.team_stats.summary}]")
+    println(s"[${state.opponent_stats.summary}]")
+    println("-------------------------")
+  }
+
+  /** Returns team and opponent possessions based on the lineup data */
   def calculate_possessions(
+    lineup_events: Seq[LineupEvent]
+  ): List[LineupEvent] = {
+
+    var diagnostic_state = PossState.init
+
+    val enriched_lineups = decompose_lineups(lineup_events).map {
+      case LineupDecomp(lineup, next_lineup, reverse_prev_lineups) =>
+        val start_of_next =
+          get_first_clump(next_lineup.map(_.raw_game_events.filter {
+            case LineupEvent.RawGameEvent.Opponent(EventUtils.ParseTeamSubIn(_)) => false
+            case LineupEvent.RawGameEvent.Opponent(EventUtils.ParseTeamSubOut(_)) => false
+            case _ => true
+          }).getOrElse(Nil))
+
+        val Last2Clumps(end_of_curr, _) = get_last_clumps(lineup.raw_game_events)
+        val start_of_curr = get_first_clump(lineup.raw_game_events)
+        val Last2Clumps(prev, prevprev) = get_last_clumps(reverse_prev_lineups.flatMap(_.raw_game_events))
+
+        def half_time_boundary(later: Option[String], earlier: Option[String]): Boolean =
+          later.flatMap(l => earlier.map(e => (e, l))).exists(e_l => e_l._1 > e_l._2)
+
+        val (team_fragment, opponent_fragment) = (lineup.raw_game_events match { //(filter the end of the lineup)
+          case l if half_time_boundary(start_of_next.date_str, end_of_curr.date_str) => //half time!
+            l
+          case l if start_of_next.min.nonEmpty && (start_of_next.min == end_of_curr.min) =>
+            // Exclude the final concurrent clump because we handled it last iteration
+            val min_to_exclude = start_of_next.min.getOrElse(-1.0)
+/**///TODO: can this actually happen? I don't _think_ so
+            if (prev.min == min_to_exclude) {
+              println(s">>>>>>>>>>>>>> problem case: [$start_of_next][$end_of_curr][$start_of_next][$prev]")
+            }
+            l.filterNot(_.min == min_to_exclude)
+          case l =>
+            l
+        }) match { //(pick the right bits of curr/prev and calculate possessions)
+          case l if half_time_boundary(start_of_curr.date_str, prev.date_str) => //half time!
+            calculate_possessions(l, Nil) //TODO: need to clear prevprev?
+          case l if start_of_curr.min.nonEmpty && (start_of_curr.min == prev.min) =>
+            calculate_possessions(prev.evs ++ l, prevprev.evs)
+          case l =>
+            calculate_possessions(l, prev.evs)
+        }
+//TODO: this is still wrong :(
+
+        // Validation and stats collection
+
+        diagnostic_state = diagnostic_state.copy(
+          team_stats = diagnostic_state.team_stats.sum(team_fragment),
+          opponent_stats = diagnostic_state.opponent_stats.sum(opponent_fragment)
+        )
+
+        //Validate no nasty lineup stats:
+        def validate_lineup(fragment: PossCalcFragment, stats: LineupEventStats): Unit =
+          if ((fragment.total_poss < 0) || ((fragment.total_poss == 0) && (stats.pts > 0))) {
+            println(
+              s"Possession problem: [${fragment.summary}] vs [$start_of_next] >> [$lineup] >> [$prev] >> [$prevprev]"
+            )
+          }
+//TODO: example of lineup getting its possession stolen:
+//Possession problem: [total=[-1] = shots=[2] - (orbs=[3] + db_orbs=[0]) + (ft_sets=[0] - techs=[0]) + to=[0] { +1s=[0] offset_techs=[0] }]
+// next (t1): foul, FTM, FTm, ORB, make
+// curr (t2->t3): (t)ORB, FGm, foul, ORB, FGm, ORB
+//(ie next+curr) would be 1 ft_set, 4 ORBs, 1 make, 2 misses == 0 possessions
+//(confusing because of ORB to start the lineup, but don't have a real val for prev lineup so....)
+//TOOD: check for "10:08:00,13-22,Team, rebound offensive team" in NCAT game
+// prev (t4): turnover
+// Extreme oddity: t1->t3 == 10.28->9.87 ... BUT t4==3.47, so clearly (seperate) bug there
+
+//TODO: need to decide what I mean by a possession eg in the above case, L1 and L2 legit are using the same
+// L1 has no conclusion... prob L1 should be (0, 0) and L2 should be (1, 0)?
+// (note that this might be differnet in the two different directions)
+
+        validate_lineup(team_fragment, lineup.team_stats)
+        validate_lineup(opponent_fragment, lineup.opponent_stats)
+
+        // Possession-enriched lineup data
+
+        lineup.copy(
+          team_stats = lineup.team_stats.copy(
+            num_possessions = team_fragment.total_poss
+          ),
+          opponent_stats = lineup.opponent_stats.copy(
+            num_possessions = opponent_fragment.total_poss
+          )
+        )
+    }
+    if (show_end_of_lineup_calcs) {
+      summarize_state("-END-", diagnostic_state)
+    }
+    enriched_lineups.toList
+  }
+//TODO TOTEST
+
+  /** Returns team and opponent possessions based on the raw event data */
+  protected def calculate_possessions(
     raw_events: Seq[LineupEvent.RawGameEvent],
     previous_events: Seq[LineupEvent.RawGameEvent]
   ): (PossCalcFragment, PossCalcFragment) =
   {
-    val show_end_of_calcs = true
-    def summarize_state(label: String, state: PossState): Unit = {
-      println(s"--------$label------------")
-      println(s"[${state.team_stats.summary}]")
-      println(s"[${state.opponent_stats.summary}]")
-      println("-------------------------")
-    }
 
     val clumped_events = raw_events.map(ev => ConcurrentClump(ev :: Nil))
     StateUtils.foldLeft(
-      clumped_events, PossState.init, classOf[LineupEvent.RawGameEvent], concurrent_event_handler
+      clumped_events, PossState.init,
+      classOf[LineupEvent.RawGameEvent], concurrent_event_handler[PossState]
     ) {
       case StateEvent.Next(ctx, state, clump @ ConcurrentClump(evs)) =>
         val new_state = state.copy(
@@ -386,7 +496,7 @@ trait PossessionUtils {
         ctx.stateChange(new_state)
 
       case StateEvent.Complete(ctx, state) => //(no additional processing when element list complete)
-        if (show_end_of_calcs) {
+        if (show_end_of_raw_calcs) {
           summarize_state("-END-", state)
         }
         ctx.noChange
@@ -396,6 +506,56 @@ trait PossessionUtils {
     }
 
   } //(end calculate_possessions)
+
+  /** Gets the first clump of a lineup (to compare with the "previous" in possession calcs) */
+  protected def get_first_clump(evs: Seq[LineupEvent.RawGameEvent]): ConcurrentClump = {
+    val ev_clumps = evs.map(ev => ConcurrentClump(List(ev)))
+    StateUtils.foldLeft(
+      ev_clumps, ConcurrentClump(Nil), concurrent_event_handler[ConcurrentClump]
+    ) {
+      case StateEvent.Next(ctx, state, clump) if state.evs == Nil =>
+        ctx.stateChange(clump)
+      case StateEvent.Next(ctx, _, _)  =>
+        ctx.noChange
+      case StateEvent.Complete(ctx, _) =>
+        ctx.noChange
+    } match {
+      case FoldStateComplete.State(state) => state
+    }
+  }
+//TODO TOTEST
+
+  /** Gets the final clump of a lineup (to use as the "previous" in possession calcs) */
+  protected def get_last_clumps(evs: Seq[LineupEvent.RawGameEvent]): Last2Clumps = {
+    val start_state = Last2Clumps(ConcurrentClump(Nil), ConcurrentClump(Nil))
+    val ev_clumps = evs.map(ev => ConcurrentClump(List(ev)))
+    StateUtils.foldLeft(
+      ev_clumps, start_state, concurrent_event_handler[Last2Clumps]
+    ) {
+      case StateEvent.Next(ctx, state, clump) =>
+        ctx.stateChange(state.copy(prev = clump, prevprev = state.prev))
+      case StateEvent.Complete(ctx, _) =>
+        ctx.noChange
+    } match {
+      case FoldStateComplete.State(state) => state
+    }
+  }
+//TODO TOTEST
+
+  /** Decompose the lineup - resulting objects */
+  protected def decompose_lineups(evs: Seq[LineupEvent]): Seq[LineupDecomp] = {
+    //ie (1, Some(2)), (2, Some(3)), (N, None)
+    val start_state: LineupDecomp = null
+    (evs zip (evs.drop(1).map(Some(_)) ++ List(None))).scanLeft(start_state) {
+      case (`start_state`, (ev, next_ev)) =>
+        LineupDecomp(ev, next_ev, Nil)
+      case (LineupDecomp(curr, _, reverse_prevs), (ev, next_ev)) =>
+        LineupDecomp(ev, next_ev, curr :: reverse_prevs)
+        //(generates LineupDecomp(1, Some(2), nil), LineupDecom(2, Some(3), L(1)), etc)
+    }.drop(1) //ignore starting state
+  }
+//TODO TOTEST
+
 
 }
 object PossessionUtils extends PossessionUtils

--- a/src/main/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/PossessionUtils.scala
+++ b/src/main/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/PossessionUtils.scala
@@ -1,0 +1,292 @@
+package org.piggottfamily.cbb_explorer.utils.parsers.ncaa
+
+import org.piggottfamily.utils.StateUtils
+import org.piggottfamily.cbb_explorer.models._
+import org.piggottfamily.cbb_explorer.models.ncaa._
+
+/** Utilities related to calculation possession from raw game events */
+trait PossessionUtils {
+  import ExtractorUtils._
+  import StateUtils.StateTypes._
+
+  // Lots of data modelling:
+
+  /** Which team is in possession */
+  protected object Direction extends Enumeration {
+    val Init, Team, Opponent = Value
+
+    /** Switch direction */
+    def opposite(dir: Direction.Value): Direction.Value = dir match {
+      case Direction.Init => dir
+      case Direction.Team => Direction.Opponent
+      case Direction.Opponent => Direction.Team
+    }
+  }
+  /** State for building possession events */
+  protected case class PossState(
+    team: Int, opponent: Int,
+    direction: Direction.Value,
+    possession_arrow: Direction.Value, //(who gets possession next game break)
+    possession_unclear: Boolean
+  )
+  protected object PossState {
+    /** Starting state */
+    def init: PossState  = PossState(
+      0, 0, Direction.Init, Direction.Init, false
+    )
+    /** Handles concurrency issues with the input data */
+    case class ConcurrencyState(
+      last_min: Double
+    )
+    object ConcurrencyState {
+      /** Starting state */
+      def init: ConcurrencyState = ConcurrencyState(-1.0)
+    }
+  }
+
+  protected case class ConcurrentClump(evs: List[Model.PlayByPlayEvent])
+
+  protected sealed trait PossessionStatus
+  protected case object PossessionArrowSwitch extends PossessionStatus
+  protected case object PossessionUnclear extends PossessionStatus
+  protected case object PossessionContinues extends PossessionStatus
+  protected case class PossessionEnd(last_clump: Boolean = false) extends PossessionStatus
+
+  protected case class PossessionEvent(dir: Direction.Value) {
+    /** The team in possession */
+    object AttackingTeam {
+      def unapply(x: Model.PlayByPlayEvent): Option[String] = x match {
+        case Model.OtherTeamEvent(_, _, _, event_str) if dir == Direction.Team => Some(event_str)
+        case Model.OtherOpponentEvent(_, _, _, event_str) if dir == Direction.Opponent => Some(event_str)
+        case _ => None
+      }
+    }
+    /** The team not in possession */
+    object DefendingTeam {
+      def unapply(x: Model.PlayByPlayEvent): Option[String] = x match {
+        case Model.OtherTeamEvent(_, _, _, event_str) if dir == Direction.Opponent => Some(event_str)
+        case Model.OtherOpponentEvent(_, _, _, event_str) if dir == Direction.Team => Some(event_str)
+        case _ => None
+      }
+    }
+  }
+
+  /** Util methods */
+
+  /** Identify concurrent events (easy) */
+  protected def check_for_concurrent_event(
+    ev: Clumper.Event[PossState, PossState.ConcurrencyState, ConcurrentClump]
+  ): (PossState.ConcurrencyState, Boolean) = ev match {
+    case Clumper.Event(_, cs, Nil, ConcurrentClump(ev :: _)) =>
+      //(first event always gens a clump, possibly of size 1)
+      (cs.copy(last_min = ev.min), true)
+    case Clumper.Event(_, cs, _, ConcurrentClump((ev: Model.MiscGameBreak) :: _)) =>
+      // Game breaks can never be part of a clump
+      (cs.copy(last_min = -1.0), false)
+    case Clumper.Event(_, cs, _, ConcurrentClump(ev :: _)) if ev.min == cs.last_min =>
+      (cs, true)
+    case Clumper.Event(_, cs, _, ConcurrentClump(ev :: _)) =>
+      (cs.copy(last_min = ev.min), false)
+    case Clumper.Event(_, cs, _, ConcurrentClump(Nil)) => //(empty ConcurrentClump, not possible by construction)
+      (cs, true)
+  }
+
+  /** Aggregates all concurrent clumps of 1 event into a single clump of many events */
+  protected def rearrange_concurrent_event(
+    s: PossState, cs: PossState.ConcurrencyState, reverse_clump: List[ConcurrentClump]
+  ): List[ConcurrentClump] = {
+    List(ConcurrentClump(
+      reverse_clump.foldLeft(List[Model.PlayByPlayEvent]()) { (acc, v) => v.evs ++ acc } //(re-reverses it)
+    ))
+  }
+
+  /** Figure out who has possession to start the game */
+  protected def first_possession_status(evs: List[Model.PlayByPlayEvent]): Option[Direction.Value] = {
+    evs.collect {
+      case Model.OtherTeamEvent(_, _, _, EventUtils.ParseCommonOffensiveEvent(_)) =>
+        Direction.Team
+      case Model.OtherTeamEvent(_, _, _, EventUtils.ParseCommonDefensiveEvent(_)) =>
+        Direction.Opponent
+      case Model.OtherOpponentEvent(_, _, _, EventUtils.ParseCommonOffensiveEvent(_)) =>
+        Direction.Opponent
+      case Model.OtherOpponentEvent(_, _, _, EventUtils.ParseCommonDefensiveEvent(_)) =>
+        Direction.Team
+    }.headOption
+  }
+
+  /** Process the events within a concurrent clump to see if the possession is changing/has changed */
+  protected def clump_possession_status(
+    state: PossState,
+    evs: List[Model.PlayByPlayEvent]
+  ): PossessionStatus =
+  {
+    val dir = state.direction
+    val defendingTeam = PossessionEvent(dir).DefendingTeam
+    val attackingTeam = PossessionEvent(dir).AttackingTeam
+
+    /** This is the highest prio .. if the defending team rebounds it, they now have possession */
+    def defensive_rebound(evs: List[Model.PlayByPlayEvent]): Boolean = evs.collect {
+      case defendingTeam(EventUtils.ParseRebound(_)) => ()
+    }.nonEmpty
+
+    def offensive_rebound(evs: List[Model.PlayByPlayEvent]): Boolean = evs.collect {
+      case attackingTeam(EventUtils.ParseRebound(_)) => ()
+    }.nonEmpty
+
+    /** Offensive turnover */
+    def offensive_turnover(evs: List[Model.PlayByPlayEvent]): Boolean = evs.collect {
+      case attackingTeam(EventUtils.ParseTurnover(_)) => ()
+    }.nonEmpty
+
+    /** Made shot and missed the and one ... need to wait for DRB */
+    def missed_and_one(evs: List[Model.PlayByPlayEvent]): Boolean = evs.collect {
+      case attackingTeam(EventUtils.ParseFreeThrowMissed(_)) => ()
+    }.nonEmpty
+
+    /** Made shot (use order of clauses to ensure there was no missed and-1) */
+    def made_shot(evs: List[Model.PlayByPlayEvent]): Boolean = evs.collect {
+      case attackingTeam(EventUtils.ParseShotMade(_)) => ()
+    }.nonEmpty
+
+    /** Took free throws and hit at least one of them */
+    def fts_some_made(evs: List[Model.PlayByPlayEvent]): Boolean = evs.collect {
+      case attackingTeam(EventUtils.ParseFreeThrowMade(_)) => ()
+    }.nonEmpty
+
+    /** Took free throws and missed at least one of them */
+    def fts_some_missed(evs: List[Model.PlayByPlayEvent]): Boolean = evs.collect {
+      case attackingTeam(EventUtils.ParseFreeThrowMissed(_)) => ()
+    }.nonEmpty
+
+    def technical_foul(evs: List[Model.PlayByPlayEvent]): Boolean = evs.collect {
+      case defendingTeam(EventUtils.ParseTechnicalFoul(_)) => ()
+    }.nonEmpty
+
+    def end_of_period(evs: List[Model.PlayByPlayEvent]): Boolean = evs.collect {
+      case _: Model.MiscGameBreak => ()
+    }.nonEmpty
+
+    //TODO: error on inconsistencies rather than silently give the wrong possession count
+
+    evs match {
+      case _ if end_of_period(evs) => PossessionArrowSwitch
+
+      case _ if defensive_rebound(evs) => PossessionEnd(last_clump = true)
+
+      case _ if state.possession_unclear && !offensive_rebound(evs) => PossessionEnd(last_clump = true)
+        //(see the case that generates PossessionUnclear, below)
+
+      case _ if offensive_turnover(evs) => PossessionEnd()
+
+      case _ if technical_foul(evs) && (fts_some_missed(evs) || fts_some_made(evs)) => PossessionContinues
+        //(if the defending team is called for a technical, the offensive team will get the ball back)
+
+      case _ if made_shot(evs) && missed_and_one(evs) => PossessionContinues //(wait for the rebound)
+      case _ if made_shot(evs) => PossessionEnd()
+
+      case _ if fts_some_missed(evs) && fts_some_made(evs) => PossessionUnclear
+        //(the problem here is that with legacy data we don't know if the last one missed ...
+        // what happens is if there's no rebound on either side then possession changes
+        // if there's a DRB possession changes are per usual, and otherwise (==ORB) possession continues)
+
+      case _ if fts_some_missed(evs) => PossessionContinues //(all FTs missed => last FT missed => wait for the rebound)
+      case _ if fts_some_made(evs) => PossessionEnd()
+      case _ => PossessionContinues
+    }
+  }
+
+  /** Returns team and opponent possessions based on the raw event data */
+  def calculate_possessions(
+    raw_events: Seq[Model.PlayByPlayEvent]
+  ): List[Model.PlayByPlayEvent] =
+  {
+    /** Adds possession count to raw event */
+    def enrich(state: PossState, ev: Model.PlayByPlayEvent): Model.PlayByPlayEvent = ev match {
+      case game_ev: Model.MiscGameEvent if (state.direction == Direction.Team) =>
+        game_ev.with_poss(state.team)
+      case game_ev: Model.MiscGameEvent if (state.direction == Direction.Opponent) =>
+        game_ev.with_poss(state.opponent)
+      case _ => ev
+    }
+
+    /** Sort out state if possession changes */
+    def switch_state(state: PossState): PossState = {
+      if (state.direction == Direction.Team) {
+        state.copy(
+          opponent = state.opponent + 1, direction = Direction.Opponent,
+          possession_unclear = false
+        )
+      } else { //(must be Opponent, not Init, by construction)
+        state.copy(
+          team = state.team + 1, direction = Direction.Team,
+          possession_unclear = false
+        )
+      }
+    }
+
+    /** Updates the state and enriches the events with poss number based on incoming clump */
+    def handle_clump(
+      state: PossState, evs: List[Model.PlayByPlayEvent]
+    ): (PossState, List[Model.PlayByPlayEvent]) = clump_possession_status(state, evs) match {
+      case PossessionArrowSwitch =>
+        val new_state = switch_state(state).copy(
+          direction = state.possession_arrow,
+          possession_arrow = Direction.opposite(state.possession_arrow)
+        )
+        //Game break meaning whoever has the possession arrow gets the ball, so may or may not`
+        //get consecutive possessions on either side
+        (new_state, evs.map(ev => enrich(state, ev)))
+
+      case PossessionEnd(true) =>
+        val new_state = switch_state(state)
+        handle_clump(new_state, evs) //(can't recurse more than once by construction)
+      case PossessionEnd(false) =>
+        val new_state = switch_state(state)
+        (new_state, evs.map(ev => enrich(state, ev)))
+        //(use the old stqte because it's the _next_ clump that belongs to the update possession count)
+      case PossessionUnclear =>
+        (state.copy(possession_unclear = true), evs.map(ev => enrich(state, ev)))
+      case PossessionContinues =>
+        (state.copy(possession_unclear = false), evs.map(ev => enrich(state, ev)))
+    }
+
+    /** Manages splitting stream into concurrent chunks and then combining them */
+    val concurrent_event_handler = Clumper(
+      PossState.ConcurrencyState.init,
+      check_for_concurrent_event _,
+      rearrange_concurrent_event _
+    )
+
+    val clumped_events = raw_events.map(ev => ConcurrentClump(List(ev)))
+    (StateUtils.foldLeft(
+      clumped_events, PossState.init, classOf[Model.PlayByPlayEvent], concurrent_event_handler
+    ) {
+      case StateEvent.Next(ctx, state, ConcurrentClump(evs)) if state.direction == Direction.Init =>
+        // First state, who has the first possession?
+        val (new_state, enriched_evs) = first_possession_status(evs) match {
+          case Some(dir) =>
+            val opposite_dir = Direction.opposite(dir)
+            val new_state = switch_state(state.copy( //(abuse switch_state for 1st poss)
+              direction = opposite_dir, possession_arrow = opposite_dir
+            ))
+            handle_clump(new_state, evs)
+          case _ =>
+            (state, evs) //(do nothing, wait for next clump)
+        }
+        ctx.stateChange(new_state, enriched_evs)
+
+      case StateEvent.Next(ctx, state, ConcurrentClump(evs)) => // Standard processing
+        val (new_state, enriched_evs) = handle_clump(state, evs)
+        ctx.stateChange(new_state, enriched_evs)
+
+      case StateEvent.Complete(ctx, _) => //(no additional processing when element list complete)
+        ctx.noChange
+
+    }) match {
+      case FoldStateComplete(_, events) =>
+        events
+    }
+
+  } //(end calculate_possessions)
+}
+object PossessionUtils extends PossessionUtils

--- a/src/main/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/PossessionUtils.scala
+++ b/src/main/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/PossessionUtils.scala
@@ -20,36 +20,14 @@ trait PossessionUtils {
   )
   // Compare to previous results
   (x1 zip x2).map { case (k, v) => k._1 -> (k._2._1 - v._2._1, k._2._2 - v._2._2) }
-
-  //Or (checking vs raw game events):
-  l.groupBy(t => (t.opponent, t.location_type)).mapValues { ev =>
-    ev.headOption.map(_.date) -> ev.flatMap(_.raw_game_events).reverse.flatMap(ev => ev.team_possession.orElse(ev.opponent_possession)).headOption
-  }.toList.sortBy(_._2._1.toString)
-
-  // Number of missing possessions:
-  l.groupBy(t => (t.opponent, t.location_type)).mapValues { ev =>
-     ev.headOption.map(_.date) -> ev.flatMap(_.raw_game_events).count(ev => ev.toString.contains("MISSING_POSSESSION"))
-  }.toList.sortBy(_._2._1.toString)
   */
 
 /** Problems:
 
-NCAT: missed an and-one, so over-counted FTs
-19:10:00	Tyrone Lyons, 2pt jumpshot 2ndchance;fromturnover;pointsinthepaint made	27-49
-19:06:00		27-49	Bruno Fernando, foul personal shooting;1freethrow
-19:06:00	Tyrone Lyons, foulon	27-49
-19:06:00	Tyrone Lyons, freethrow 1of1 2ndchance;fastbreak;fromturnover made
-(fixed this ... but .....)
-Ah but if you miss the front-end of a 1-1 then you get it wrong also...
-00:50:40	Ty Jerome, freethrow 1of1 fastbreak missed	70-65
-00:50:40		70-65	Bruno Fernando, rebound defensive
-00:50:40		70-65	Aaron Wiggins, foul personal oneandone
-
-UVA discrepancy is weird:
-[INFO] Parsed box score: opponent=[TeamSeasonId(TeamId(Virginia),Year(2018))] venue=[Home]
---------------------
-[50 - 10 + 7 + 14 = 61]
-[59 - 9 + ~6~ 7 + 2 = ~58~ 59] so still a diff of 2 even with the FT fix
+Delaware game:
+00:00:10		27-44	Jalen Smith, 3pt jumpshot fromturnover missed
+00:00:10		27-44	Team, rebound offensivedeadball
+I do always filter these out, but I thought I found some cases where they were relevant .. need to search
 
 */
 
@@ -58,26 +36,17 @@ UVA discrepancy is weird:
   /** Which team is in possession */
   protected object Direction extends Enumeration {
     val Init, Team, Opponent = Value
-
-    /** Switch direction */
-    def opposite(dir: Direction.Value): Direction.Value = dir match {
-      case Direction.Init => dir
-      case Direction.Team => Direction.Opponent
-      case Direction.Opponent => Direction.Team
-    }
   }
   /** State for building possession events */
   protected case class PossState(
-    team: Int, opponent: Int,
-    direction: Direction.Value,
-    possession_arrow: Direction.Value, //(who gets possession next game break)
     team_stats: StatsFragment,
-    opponent_stats: StatsFragment
+    opponent_stats: StatsFragment,
+    prev_clump: ConcurrentClump
   )
   protected object PossState {
     /** Starting state */
     def init: PossState  = PossState(
-      0, 0, Direction.Init, Direction.Init, StatsFragment(), StatsFragment()
+      StatsFragment(), StatsFragment(), ConcurrentClump(Nil)
     )
     /** Handles concurrency issues with the input data */
     case class ConcurrencyState(
@@ -90,12 +59,6 @@ UVA discrepancy is weird:
   }
 
   protected case class ConcurrentClump(evs: List[Model.PlayByPlayEvent])
-
-  protected sealed trait PossessionStatus
-  protected case object PossessionArrowSwitch extends PossessionStatus
-  protected case object PossessionError extends PossessionStatus
-  protected case object PossessionContinues extends PossessionStatus
-  protected case object PossessionEnd extends PossessionStatus
 
   protected case class PossessionEvent(dir: Direction.Value) {
     /** The team in possession */
@@ -116,61 +79,208 @@ UVA discrepancy is weird:
     }
   }
 
-/**/
-case class StatsFragment(
-  shots_made_or_missed: Int = 0,
-  total_number_of_orbs: Int = 0,
-  total_number_of_ft_events: Int = 0,
-  total_number_of_tos: Int = 0
-) {
-  def sum(rhs: StatsFragment) = this.copy(
-    shots_made_or_missed = this.shots_made_or_missed + rhs.shots_made_or_missed,
-    total_number_of_orbs = this.total_number_of_orbs + rhs.total_number_of_orbs,
-    total_number_of_ft_events = this.total_number_of_ft_events + rhs.total_number_of_ft_events,
-    total_number_of_tos = this.total_number_of_tos + rhs.total_number_of_tos,
-  )
-  def total_poss = {
-    shots_made_or_missed - total_number_of_orbs + total_number_of_ft_events + total_number_of_tos
+  /** Maintains stats needed to calculate possessions for each lineup event */
+  protected case class StatsFragment(
+    shots_made_or_missed: Int = 0,
+    liveball_orbs: Int = 0,
+    actual_deadball_orbs: Int = 0,
+    ft_events: Int = 0,
+    ignored_and_ones: Int = 0,
+    turnovers: Int = 0,
+    bad_fouls: Int = 0,
+    offsetting_bad_fouls: Int = 0
+  ) {
+    def sum(rhs: StatsFragment) = this.copy(
+      shots_made_or_missed = this.shots_made_or_missed + rhs.shots_made_or_missed,
+      liveball_orbs = this.liveball_orbs + rhs.liveball_orbs,
+      actual_deadball_orbs = this.actual_deadball_orbs + rhs.actual_deadball_orbs,
+      ft_events = this.ft_events + rhs.ft_events,
+      ignored_and_ones = this.ignored_and_ones + rhs.ignored_and_ones,
+      bad_fouls = this.bad_fouls + rhs.bad_fouls,
+      offsetting_bad_fouls = this.offsetting_bad_fouls + rhs.offsetting_bad_fouls,
+      turnovers = this.turnovers + rhs.turnovers
+    )
+    def total_poss = {
+      shots_made_or_missed - (liveball_orbs + actual_deadball_orbs) +
+      (ft_events - bad_fouls) + turnovers
+    }
+    def summary: String = {
+      s"total=[$total_poss] = " +
+      s"shots=[$shots_made_or_missed] - (orbs=[$liveball_orbs] + db_orbs=[$actual_deadball_orbs]) + " +
+      s"(ft_sets=[$ft_events] - techs=[$bad_fouls]) + to=[$turnovers]" +
+      s"{ +1s=[$ignored_and_ones] offsetting_techs=[$offsetting_bad_fouls] }"
+    }
   }
-  def summary: String = {
-    s"${shots_made_or_missed} - ${total_number_of_orbs} + ${total_number_of_ft_events} + ${total_number_of_tos} = $total_poss"
-  }
-}
+
+  /** Util methods */
+
+  /** Calculates the possessions from a block of data (eg game or lineup)
+      for one direction only. As stateless and independent in the 2 dirs as possible!
+
+  Here's an example where we get it wrong:
+    10:04:00     Kevin Anderson, 3pt jumpshot missed     42-58
+  10:02:00     Eric Carter, freethrow 1of1 made     45-58
+  10:02:00         44-58     Bruno Fernando, foul personal shooting;1freethrow
+  10:02:00     Eric Carter, 2pt layup pointsinthepaint made     44-58
+  10:02:00         42-58     Eric Ayala, rebound defensive
+  10:02:00     Ryan Johnson, foulon     44-58
+  ...there's _probably_ a missing turnover, don't think there's much we can do about it
+
+  TODO: longer term need a context of nearby events, though this wouldn't have helped here
+  */
   def calculate_stats(clump: List[Model.PlayByPlayEvent], dir: Direction.Value): StatsFragment = {
     val attackingTeam = PossessionEvent(dir).AttackingTeam
+    val defendingTeam = PossessionEvent(dir).DefendingTeam
 
-    val ft_event_this_clump = clump.collect {
+    val ft_event_this_clump: Boolean = clump.collect {
       case attackingTeam(EventUtils.ParseFreeThrowMade(_)) => ()
       case attackingTeam(EventUtils.ParseFreeThrowMissed(_)) => ()
     }.nonEmpty
-    val and_one = clump.collect {
+
+    /** Examples:
+    Actual and-one:
+    19:10:00	Tyrone Lyons, 2pt jumpshot 2ndchance;fromturnover;pointsinthepaint made	27-49
+    19:06:00		27-49	Bruno Fernando, foul personal shooting;1freethrow
+    19:06:00	Tyrone Lyons, foulon	27-49
+    19:06:00	Tyrone Lyons, freethrow 1of1 2ndchance;fastbreak;fromturnover made
+
+    Event more confusing version:
+    (i rearranged every line of the 1:33 section to make it somewhat readable!)
+    01:36:00		68-60	Eric Ayala, 3pt jumpshot missed
+    01:33:00	Jack Salt, rebound defensive	68-60
+    01:33:00	Jack Salt, foulon	68-60
+    01:33:00		68-60	Bruno Fernando, foul personal 1freethrow (<-this normally means and-1)
+    01:33:00	Jack Salt, freethrow 1of1 fastbreak missed	68-60
+    01:33:00		70-62	Jalen Smith, rebound defensive (<--THE SCORE IS EVEN WRONG HERE)
+    01:33:00	De'Andre Hunter, 2pt dunk pointsinthepaint;fastbreak made	70-60
+    01:33:00	Kyle Guy, assist	70-60
+    01:33:00		70-62	Anthony Cowan, 2pt layup pointsinthepaint made
+
+    One-and-one to confuse things:
+    00:50:40	Ty Jerome, freethrow 1of1 fastbreak missed	70-65
+    00:50:40		70-65	Bruno Fernando, rebound defensive
+    00:50:40		70-65	Aaron Wiggins, foul personal oneandone
+
+    TODO; old format
+    */
+    val and_one: Int = clump.collect {
+      //TODO: fix "and one" detection
+
       case attackingTeam(EventUtils.ParseFreeThrowMade(_)) => ()
       case attackingTeam(EventUtils.ParseFreeThrowMissed(_)) => ()
-    }.size == 1
+    }.size
 
     val filtered_clump = clump.filter {
       case attackingTeam(EventUtils.ParseTeamDeadballRebound(_)) => false
       case _ => true
     }
+
     // Shots made or missed
-    val shots_made_or_missed = filtered_clump.collect {
+    val shots_made_or_missed: Int = filtered_clump.collect {
       case attackingTeam(EventUtils.ParseShotMade(_)) => ()
       case attackingTeam(EventUtils.ParseShotMissed(_)) => ()
     }.size
-    val total_number_of_ft_events = if (ft_event_this_clump && !and_one) 1 else 0
-    val total_number_of_orbs = filtered_clump.collect {
+
+    // Free throws
+    val ft_event: Int = if (ft_event_this_clump && (and_one == 0)) 1 else 0
+
+    /** Technicals and flagrants, examples:
+      Technical:
+        14:27:00	Eric Carter, 2pt layup pointsinthepaint made	36-56
+        14:26:00	Eric Carter, foul technical classa;2freethrow	36-56
+        14:26:00		36-58	Anthony Cowan, freethrow 2of2 fastbreak made
+        14:26:00		36-57	Anthony Cowan, freethrow 1of2 fastbreak made
+        14:06:00	Eric Carter, block	36-58
+        14:06:00		36-58	Jalen Smith, 2pt layup blocked missed
+      Flagrant:
+        03:44:00	Ithiel Horton, 2pt layup missed	60-67
+        03:42:00		62-67	Darryl Morsell, freethrow 1of2 fastbreak missed
+        03:42:00		60-67	Aaron Wiggins, foulon
+        03:42:00	Eric Carter, freethrow 1of2 made	61-67
+        03:42:00	Eric Carter, freethrow 2of2 made	62-67
+        03:42:00		62-67	Team, rebound offensivedeadball
+        03:42:00		62-68	Darryl Morsell, freethrow 2of2 fastbreak made
+        03:42:00	Eric Carter, foul personal flagrant1;2freethrow	60-67
+        03:42:00		60-67	Darryl Morsell, substitution in
+        03:42:00	timeout commercial
+        03:42:00	Kevin Anderson, foulon	60-67
+        03:42:00		60-67	Bruno Fernando, substitution out
+        03:42:00		60-67	Bruno Fernando, foul personal oneandone
+        03:42:00	Kevin Anderson, rebound offensive	60-67
+        03:24:00		62-70	Eric Ayala, 2pt jumpshot made
+      Offsetting:
+        07:43:00		51-61	Aaron Wiggins, rebound defensive
+        07:28:00	Kevin Anderson, foulon	51-61
+        07:28:00		51-61	Ivan Bender, foul personal flagrant1
+        07:28:00		51-61	Ivan Bender, foulon
+        07:28:00	Kevin Anderson, foul personal flagrant1	51-61
+        07:10:00		51-61	Anthony Cowan, 2pt jumpshot missed
+
+  TODO; old format
+    */
+
+    val offsetting_tech: Int = if (filtered_clump.collect {
+      case attackingTeam(EventUtils.ParseTechnicalFoul(_)) => ()
+    }.nonEmpty && filtered_clump.collect {
+      case defendingTeam(EventUtils.ParseTechnicalFoul(_)) => ()
+    }.nonEmpty) 1 else 0
+
+    val offsetting_flagrant: Int = if (filtered_clump.collect {
+      case attackingTeam(EventUtils.ParseFlagrantFoul(_)) => ()
+    }.nonEmpty && filtered_clump.collect {
+      case defendingTeam(EventUtils.ParseFlagrantFoul(_)) => ()
+    }.nonEmpty) 1 else 0
+
+    val techs_or_flagrant: Int = (if (filtered_clump.collect {
+      case defendingTeam(EventUtils.ParseTechnicalFoul(_)) => ()
+      case defendingTeam(EventUtils.ParseFlagrantFoul(_)) => ()
+    }.nonEmpty) 1 else 0) - offsetting_tech - offsetting_flagrant
+
+    val orbs: Int = filtered_clump.collect {
       case attackingTeam(EventUtils.ParseOffensiveRebound(_)) => ()
     }.size
-    val total_number_of_tos = filtered_clump.collect {
+
+    /** Examples:
+    Filter this out, but not because it's part of a FT even, it's at "end of period" artefact
+    00:00:10		27-44	Jalen Smith, 3pt jumpshot fromturnover missed
+    00:00:10		27-44	Team, rebound offensivedeadball
+
+    Here's one we need to process though:
+    10:02:00    Ryan Johnson, foulon    44-58
+    09:51:00        45-58    Anthony Cowan, foulon
+    09:51:00        45-58    Anthony Cowan, 3pt jumpshot missed
+    09:51:00        45-58    Team, rebound offensivedeadball
+    09:51:00    Ryan Johnson, foul personal    45-58
+    09:51:00        45-58    Ricky Lindo Jr., substitution out
+    09:51:00        45-58    Serrel Smith Jr., substitution out
+    09:51:00        45-58    Anthony Cowan, substitution in
+    09:51:00        45-58    Darryl Morsell, substitution in
+    09:51:00        45-58    Bruno Fernando, substitution out
+    09:51:00        45-58    Jalen Smith, substitution in
+    09:51:00    Ryan Johnson, substitution out    45-58
+    09:51:00    Darian Bryant, substitution in    45-58
+    09:49:00        45-58    Jalen Smith, turnover badpass
+
+TODO; old format (Don't think you get O vs D in the case)
+    */
+    val real_deadball_orbs = clump.collect {
+//TODO
+      case attackingTeam(EventUtils.ParseOffensiveRebound(_)) => ()
+    }.size
+
+    val turnovers = filtered_clump.collect {
       case attackingTeam(EventUtils.ParseTurnover(_)) => ()
     }.size
-    StatsFragment(shots_made_or_missed, total_number_of_orbs, total_number_of_ft_events, total_number_of_tos)
+
+    StatsFragment(
+      shots_made_or_missed,
+      orbs, real_deadball_orbs,
+      ft_event, and_one,
+      techs_or_flagrant, offsetting_tech + offsetting_flagrant,
+      turnovers
+    )
+
   }
-
-  /** We generate this if the possession calcuations go wrong */
-  val error_event_string = "MISSING_POSSESSION_END"
-
-  /** Util methods */
 
   /** Identify concurrent events (easy) */
   protected def check_for_concurrent_event(
@@ -196,92 +306,10 @@ case class StatsFragment(
   ): List[ConcurrentClump] = {
     val raw_list =
       reverse_clump.foldLeft(List[Model.PlayByPlayEvent]()) { (acc, v) => v.evs ++ acc } //(re-reverses it)
-
-    // In practice you can have possessions in both directions with concurrent clumps
-    // This is hard to handle. For now we'll support 1 in each direction
-    //TODO(support more)
-    // By splitting the clump into (at most) 2, 1 for each direction based on analyzing the
-    // event type (and using the prev/next if the event isn't clearly in one direction or the other)
-
-    /** Example:
-     RawGameEvent(None, Some("12:37:00,11-13,Dan Dwyer, rebound defensive"),
-     RawGameEvent(None, Some("12:16:00,14-13,Justin Wright-Foreman, 3pt jumpshot made"),
-     RawGameEvent(None, Some("12:16:00,14-13,Dan Dwyer, assist"),
-     RawGameEvent(None, Some("12:16:00,14-13,Dan Dwyer, rebound defensive"),
-     RawGameEvent(Some("12:16:00,14-13,Aaron Wiggins, 2pt layup blocked missed"),
-     RawGameEvent(None, Some("12:16:00,14-13,Desure Buie, block"),
-    */
-//TODO: this will break offsetting fouls
-
-    case class InClumpState(
-      start: List[Model.PlayByPlayEvent], //these are consistent with the current direction
-      end: List[Model.PlayByPlayEvent], //these are consistent with the switched direction
-      prev: Direction.Value)
-
-    val current_dir = s.direction
-    val next_dir = Direction.opposite(current_dir)
-
-    val attackingTeam = PossessionEvent(current_dir).AttackingTeam
-    val defendingTeam = PossessionEvent(current_dir).DefendingTeam
-
-    def get_direction(ev: Model.PlayByPlayEvent): Direction.Value = ev match {
-      case attackingTeam(EventUtils.ParseOffensiveEvent(_)) =>
-        current_dir
-      case defendingTeam(EventUtils.ParseDefensiveEvent(_)) =>
-        current_dir
-      case defendingTeam(EventUtils.ParseOffensiveEvent(_)) =>
-        next_dir
-      case attackingTeam(EventUtils.ParseDefensiveEvent(_)) =>
-        next_dir
-      case _ => Direction.Init
-    }
-
-    val InClumpState(start_evs, end_evs, _) =
-      raw_list.foldLeft(InClumpState(Nil, Nil, Direction.Init)) { (state, ev) =>
-        get_direction(ev) match {
-          // Known direction
-          case `current_dir` =>
-            state.copy(start = ev :: state.start, prev = current_dir)
-          case `next_dir` =>
-            state.copy(end = ev :: state.end, prev = next_dir)
-
-          // Unknown direction, can infer from previous:
-          case _ if state.prev == current_dir =>
-            state.copy(start = ev :: state.start)
-          case _ if state.prev == next_dir =>
-            state.copy(end = ev :: state.end)
-
-          // Unknown direction, no previous .. will fetch from next:
-          case _ =>
-            raw_list
-              .toStream.map(get_direction)
-              .filter(_ != Direction.Init)
-              .headOption match {
-                case Some(`current_dir`) =>
-                  state.copy(start = ev :: state.start, prev = current_dir)
-                case Some(_) => //(next dir)
-                  state.copy(end = ev :: state.end, prev = next_dir)
-                case None => //(default to current direction)
-                  state.copy(start = ev :: state.start, prev = current_dir)
-              }
-        }
-      }
-
-/**
-    List(
-      ConcurrentClump(
-        start_evs.reverse
-      ),
-      ConcurrentClump(
-        end_evs.reverse
-      )
-    ).filter(_.evs.nonEmpty)
-*/
-List(ConcurrentClump(
-  raw_list
-))
+    List(ConcurrentClump(
+      raw_list
+    ))
   }
-//TODO: to test
 
   /** Manages splitting stream into concurrent chunks and then combining them */
   protected val concurrent_event_handler = Clumper(
@@ -290,362 +318,42 @@ List(ConcurrentClump(
     rearrange_concurrent_event _
   )
 
-  /** Figure out who has possession to start the game */
-  protected def first_possession_status(evs: List[Model.PlayByPlayEvent]): Option[Direction.Value] = {
-    evs.collect {
-      // Take advantage of new format
-      case Model.OtherTeamEvent(_, _, _, EventUtils.ParseJumpballWon(_)) =>
-        Direction.Team
-      case Model.OtherOpponentEvent(_, _, _, EventUtils.ParseJumpballWon(_)) =>
-        Direction.Opponent
-      // Legacy calcuations:
-      case Model.OtherTeamEvent(_, _, _, EventUtils.ParseOffensiveEvent(_)) =>
-        Direction.Team
-      case Model.OtherTeamEvent(_, _, _, EventUtils.ParseDefensiveActionEvent(_)) =>
-        Direction.Opponent
-      case Model.OtherOpponentEvent(_, _, _, EventUtils.ParseOffensiveEvent(_)) =>
-        Direction.Opponent
-      case Model.OtherOpponentEvent(_, _, _, EventUtils.ParseDefensiveActionEvent(_)) =>
-        Direction.Team
-      // Note have to ignore fouls since they can be offensive or defensive, will handle that
-      // in some separate logic before the main fold, below
-    }.headOption
-  }
-
-  /** Process the events within a concurrent clump to see if the possession is changing/has changed
-   * Note that the clump has been split into "attacking" and "defending" events, so you won't ever
-   * see both in the same clump
-   */
-  protected def clump_possession_status(
-    state: PossState,
-    in_evs: List[Model.PlayByPlayEvent]
-  ): PossessionStatus =
-  {
-    val defendingTeam = PossessionEvent(state.direction).DefendingTeam
-    val attackingTeam = PossessionEvent(state.direction).AttackingTeam
-
-    /** Ignore any events that have already been processed, plus timeouts */
-    def to_ignore: Model.PlayByPlayEvent => Boolean = {
-      case ev: Model.MiscGameEvent if ev.poss > 0 => true
-      case attackingTeam(EventUtils.ParseTimeout(_)) => true
-      case defendingTeam(EventUtils.ParseTimeout(_)) => true
-        //(timeouts have no bearing on possession)
-      case _ => false
-    }
-
-    /** Error out if the possession information is inconsistent with events */
-    def invalid_possession_state(evs: List[Model.PlayByPlayEvent]): Boolean = evs.collect {
-      case attackingTeam(EventUtils.ParseDefensiveActionEvent(_)) => ()
-      case defendingTeam(EventUtils.ParseOffensiveEvent(_)) => ()
-    }.nonEmpty
-
-    /** This is the highest prio .. if the defending team rebounds it, they now have possession
-     * (note fouls on the defense following a missed shot/rebound do generate DRB events)
-    */
-    def defensive_rebound(evs: List[Model.PlayByPlayEvent]): Boolean = evs.collect {
-      case defendingTeam(EventUtils.ParseRebound(_)) => ()
-//TODO: deadball rebound as well, I think?
-    }.nonEmpty
-
-    /** Offensive turnover */
-    def offensive_turnover(evs: List[Model.PlayByPlayEvent]): Boolean = evs.collect {
-      case attackingTeam(EventUtils.ParseTurnover(_)) => ()
-      case attackingTeam(EventUtils.ParsePersonalFoul(_)) if evs.collect {
-        // Look out for offsetting personals:
-        /** Example
-        RawGameEvent(Some("07:43:00,51-61,Aaron Wiggins, rebound defensive"), None, Some(57), None),
-        RawGameEvent(None, Some("07:28:00,51-61,Kevin Anderson, foulon"), None, Some(57)),
-        RawGameEvent(Some("07:28:00,51-61,Ivan Bender, foul personal flagrant1"), None, Some(57), None),
-        RawGameEvent(Some("07:28:00,51-61,Ivan Bender, foulon"), None, Some(57), None),
-        RawGameEvent(None, Some("07:28:00,51-61,Kevin Anderson, foul personal flagrant1"), None, Some(57)),
-        RawGameEvent(Some("07:10:00,51-61,Anthony Cowan, 2pt jumpshot missed"), None, Some(58), None),
-        */
-        case defendingTeam(EventUtils.ParsePersonalFoul(_)) => ()
-      }.isEmpty => ()
-//TODO: test
-    }.nonEmpty
-
-    /** Made shot and missed the and one ... need to wait for DRB */
-    def missed_and_one(evs: List[Model.PlayByPlayEvent]): Boolean = evs.collect {
-      case attackingTeam(EventUtils.ParseFreeThrowMissed(_)) => ()
-    }.nonEmpty
-
-    /** Made shot (use order of clauses to ensure there was no missed and-1) */
-    def made_shot(evs: List[Model.PlayByPlayEvent]): Boolean = evs.collect {
-      case attackingTeam(EventUtils.ParseShotMade(_)) => ()
-    }.nonEmpty
-
-    /** Took free throws and hit at least one of them */
-    def fts_some_made(evs: List[Model.PlayByPlayEvent]): Boolean = evs.collect {
-      case attackingTeam(EventUtils.ParseFreeThrowMade(_)) => ()
-    }.nonEmpty
-
-    /** Took free throws and missed at least one of them */
-    def fts_some_missed(evs: List[Model.PlayByPlayEvent]): Boolean = evs.collect {
-      case attackingTeam(EventUtils.ParseFreeThrowMissed(_)) => ()
-    }.nonEmpty
-
-    def technical_foul_defense(evs: List[Model.PlayByPlayEvent]): Boolean = evs.collect {
-      case defendingTeam(EventUtils.ParseTechnicalFoul(_)) => ()
-    }.nonEmpty
-
-    def end_of_period(evs: List[Model.PlayByPlayEvent]): Boolean = evs.collect {
-      case _: Model.MiscGameBreak => ()
-    }.nonEmpty
-
-    /** There's a bunch of different cases here:
-     * If the missed free throw is not the final one, then you will always see a "deadball rebound", eg:
-     (New) 04:28:00		52-59	Bruno Fernando, freethrow 1of2 missed [..]
-           04:28:00		52-59	Team, rebound offensivedeadball
-     (Old) 04:33,46-45,DAVISON,BRAD missed Free Throw
-           04:33,46-45,TEAM Deadball Rebound
-           04:33,47-45,DAVISON,BRAD made Free Throw
-
-     * If the missed free throw is the final one, you may or may not see a rebound (ie it might) be in
-     * the next clump (but then it's just like any other missed shot, ie "wait for the rebound")
-     * Unfortunately figuring out last vs intermediate free throws is only possible (in old format)
-     * by checking the scores
-     */
-    def handle_missed_freethrows(evs: List[Model.PlayByPlayEvent]): PossessionStatus = {
-      evs.collect {
-        case ev @ attackingTeam(EventUtils.ParseFreeThrowMade(_)) => ev
-        case ev @ attackingTeam(EventUtils.ParseFreeThrowMissed(_)) => ev
-      }.sortBy(ev => Game.Score.unapply(ev.score)).reverse match { // reverse => highest first
-        case attackingTeam(EventUtils.ParseFreeThrowMade(_)) :: _ => //last free throw was made
-          PossessionEnd
-        case attackingTeam(EventUtils.ParseFreeThrowMissed(_)) :: _ => //last free throw was missed
-          PossessionContinues
-      }
-    }
-
-    in_evs.filterNot(to_ignore) match {
-      case evs if end_of_period(evs) => PossessionArrowSwitch
-
-      case evs if defensive_rebound(evs) => PossessionEnd
-        // (note: defensive rebounds can be concurrent with misses)
-
-      case evs if invalid_possession_state(evs) => PossessionError
-        //(it's a bit hard to parse out clumps with DRBs so we'll ignore them for invalid state checks)
-
-      case evs if offensive_turnover(evs) => PossessionEnd
-        //(if we see offensive moves from both teams in the same clump that's OK if there's
-        // a possession change in that clump)
-
-      case evs if technical_foul_defense(evs) => PossessionContinues
-        //(if the defending team is called for a technical, the offensive team will get the ball back,
-        // offensive technical fouls that result in a change of possession also generate an
-        // offensive turnover event, so can ignore)
-
-      case evs if made_shot(evs) && missed_and_one(evs) => PossessionContinues //(wait for the rebound)
-        //(any free throws must be an and-1 because technical fouls are handled above)
-      case evs if made_shot(evs) => PossessionEnd //(no and-1 because of order)
-
-      case evs if fts_some_missed(evs) => handle_missed_freethrows(evs) //untangle what happened
-      case evs if fts_some_made(evs) => PossessionEnd //(none missed because of order)
-
-      case _ => PossessionContinues
-    }
-  }
-
-  /** Calculate the possession counts within a lineup */
-  def sum_possessions(curr: LineupEvent, prevs: List[LineupEvent]): (Int, Int) = {
-    def team_or_oppo_calc(poss_getter: LineupEvent.RawGameEvent => List[Int]): Int = {
-      val max_poss = Try(Some(curr.raw_game_events.flatMap(poss_getter).max)).getOrElse(None)
-      val min_poss = Try(Some(curr.raw_game_events.flatMap(poss_getter).min)).getOrElse(None)
-      val prev = prevs.iterator.find(p => p.raw_game_events.flatMap(poss_getter).nonEmpty)
-      //(find most recent previous lineup even with a possession count)
-      val prev_poss = prev.flatMap(
-        p => Try(Some(p.raw_game_events.flatMap(poss_getter).max)).getOrElse(None)
-      )
-      (max_poss, min_poss, prev_poss) match {
-        case (Some(max), Some(min), Some(prev)) if prev == min =>
-          max - min //(min was already counted in the previous lineup)
-        case (Some(max), Some(min), _) => max - min + 1
-        case _ => 0
-      }
-    }
-    (
-      team_or_oppo_calc(_.team_possession.toList),
-      team_or_oppo_calc(_.opponent_possession.toList)
-    )
-  }
-//TODO test
-
   /** Returns team and opponent possessions based on the raw event data */
   def calculate_possessions(
     raw_events: Seq[Model.PlayByPlayEvent]
   ): List[Model.PlayByPlayEvent] =
   {
-    /** Adds possession count to raw event */
-    def enrich(state: PossState, ev: Model.PlayByPlayEvent): Model.PlayByPlayEvent = {
-      val attackingTeam = PossessionEvent(state.direction).AttackingTeam
-      ev match {
-        // Special case...  a defensive action from the previous possession:
-        /** Example:
-        RawGameEvent(Some("17:42,5-0,FERNANDO,BRUNO Defensive Rebound"),
-        RawGameEvent(Some("17:32,5-0,FERNANDO,BRUNO Turnover"),
-        */
-        case game_ev @ attackingTeam(EventUtils.ParseDefensiveInfoEvent(_)) if game_ev.poss <= 0 =>
-          game_ev.with_poss(state.direction match {
-            case Direction.Team => state.opponent
-            case Direction.Opponent => state.team
-            case _ => 0
-          })
-        case game_ev: Model.MiscGameEvent if game_ev.poss <= 0 =>
-  //TODO: oh wait this isn't right, you can have opponent actions as part of team possession etc
-          game_ev.with_poss(state.direction match {
-            case Direction.Team => state.team
-            case Direction.Opponent => state.opponent
-            case _ => 0
-          })
-        case _ => ev
-          //(never overwrite a previous possession, ie ev_poss > 0)
-      }
+    def summarize_state(label: String, state: PossState): Unit = {
+      println(s"--------$label------------")
+      println(s"[${state.team_stats.summary}]")
+      println(s"[${state.opponent_stats.summary}]")
+      println("------------------------")
     }
-
-    /** Sort out state if possession changes */
-    def switch_state(state: PossState): PossState = {
-      if (state.direction == Direction.Team) {
-        state.copy(
-          opponent = state.opponent + 1, direction = Direction.Opponent
-        )
-      } else { //(must be Opponent, not Init, by construction)
-        state.copy(
-          team = state.team + 1, direction = Direction.Team
-        )
-      }
-    }
-
-    /** Sort out state if possession changes _across game break_ */
-    def switch_state_on_game_break(state: PossState): PossState = {
-      /** Examples
-         T: made: 1
-         O: made: 1 (here, state=(T: 2, O: 1, dir=T))
-         <break, dir arrow = O|T>
-         O: made: 2 | T: made: 2
-         T: made: 2 | O: made: 2
-         (note every half ends on a made shot or a -possibly deadball? defensive rebound)
-      */
-      if (state.direction == state.possession_arrow) {
-        state
-      } else {
-        if (state.direction == Direction.Team) {
-          state.copy(
-            team = state.team - 1, opponent = state.opponent + 1, direction = Direction.Opponent
-          )
-        } else { //(must be Opponent, not Init, by construction)
-          state.copy(
-            team = state.team + 1, opponent = state.opponent - 1, direction = Direction.Team
-          )
-        }
-      }
-    }
-
-    /** If a possession has been missed, create a dummy one to keep the stats correct */
-    def inject_missed_possession(evs: List[Model.PlayByPlayEvent], dir: Direction.Value): Model.PlayByPlayEvent = {
-      /** Example of a missed possession:
-      RawGameEvent(Some("13:23:00,8-13,Bruno Fernando, foul personal shooting;2freethrow"),
-      RawGameEvent(None, Some("13:22:00,9-13,Stafford Trueheart, freethrow 2of2 2ndchance made"),
-      RawGameEvent(None, Some("13:22:00,8-13,Stafford Trueheart, freethrow 1of2 2ndchance missed"),
-      RawGameEvent(None, Some("13:22:00,8-13,Team, rebound offensivedeadball"),
-      RawGameEvent(Some("12:50:00,11-13, MISSING_POSSESSION"),
-      RawGameEvent(None, Some("12:50:00,11-13,Justin Wright-Foreman, 2pt layup pointsinthepaint made"),
-      */
-
-      val first_game_event = evs.collect {
-        case ev: Model.MiscGameEvent => ev
-      }.headOption.getOrElse(Model.OtherTeamEvent(0.0, Game.Score(0, 0), 0, ""))
-      val event_info = first_game_event.event_string.split(",", 3)
-      val event_time = event_info.lift(0).getOrElse("00:00")
-      val event_score = event_info.lift(1).getOrElse("0-0")
-      val injected_ev_str = s"${event_time},${event_score}, $error_event_string"
-      dir match { //(possession gets injected)
-        case Direction.Team => Model.OtherTeamEvent(first_game_event.min, first_game_event.score, 0, injected_ev_str)
-        case _ => Model.OtherOpponentEvent(first_game_event.min, first_game_event.score, 0, injected_ev_str)
-      }
-    }
-
-    /** Updates the state and enriches the events with poss number based on incoming clump */
-    def handle_clump(
-      state: PossState, evs: List[Model.PlayByPlayEvent]
-    ): (PossState, List[Model.PlayByPlayEvent]) = clump_possession_status(state, evs) match {
-
-      case PossessionError => //create a missed possession state and carry on
-        val dummy_event = enrich(state, inject_missed_possession(evs, state.direction))
-        val new_state = switch_state(state)
-        //(this can't recurse because each clump is guaranteeed to match one direction only)
-        handle_clump(new_state, dummy_event :: evs)
-
-      case PossessionArrowSwitch =>
-        val new_state = switch_state_on_game_break(state).copy(
-          possession_arrow = Direction.opposite(state.possession_arrow)
-        )
-        //Game break meaning whoever has the possession arrow gets the ball, so may or may not`
-        //get consecutive possessions on either side
-        (new_state, evs.map(ev => enrich(state, ev)))
-
-      case PossessionEnd =>
-        val new_state = switch_state(state)
-        (new_state, evs.map(ev => enrich(state, ev)))
-
-      case PossessionContinues =>
-        (state, evs.map(ev => enrich(state, ev)))
-    }
-
-//TODO: before we do anything else, let's check if the first possession is "difficult" and inject
-//dummy events to make life easier if so
 
     val clumped_events = raw_events.map(ev => ConcurrentClump(ev :: Nil))
     StateUtils.foldLeft(
       clumped_events, PossState.init, classOf[Model.PlayByPlayEvent], concurrent_event_handler
     ) {
-      case StateEvent.Next(ctx, state, ConcurrentClump(evs)) =>
-        ctx.stateChange(state.copy(
+      case StateEvent.Next(ctx, state, clump @ ConcurrentClump(evs)) =>
+        val new_state = state.copy(
           team_stats = state.team_stats.sum(calculate_stats(evs, Direction.Team)),
-          opponent_stats = state.opponent_stats.sum(calculate_stats(evs, Direction.Opponent))
-        ))
+          opponent_stats = state.opponent_stats.sum(calculate_stats(evs, Direction.Opponent)),
+          prev_clump = clump
+        )
+/**///display
+        if (evs.collect { case _: Model.GameBreakEvent => true }.nonEmpty) {
+          summarize_state("HALF", state)
+        }
+        ctx.stateChange(new_state)
 
       case StateEvent.Complete(ctx, state) => //(no additional processing when element list complete)
-        println("--------------------")
-        println(s"[${state.team_stats.summary}]")
-        println(s"[${state.opponent_stats.summary}]")
-        println("--------------------")
+/**///display
+        summarize_state("END-", state)
         ctx.noChange
 
     }
     raw_events.toList
 
-    /**
-    val clumped_events = raw_events.map(ev => ConcurrentClump(ev :: Nil))
-    (StateUtils.foldLeft(
-      clumped_events, PossState.init, classOf[Model.PlayByPlayEvent], concurrent_event_handler
-    ) {
-      case StateEvent.Next(ctx, state, ConcurrentClump(evs)) if state.direction == Direction.Init =>
-        // First state, who has the first possession?
-        val (new_state, enriched_evs) = first_possession_status(evs) match {
-          case Some(dir) =>
-            val opposite_dir = Direction.opposite(dir)
-            val new_state = switch_state(state.copy( //(abuse switch_state for 1st poss)
-              direction = opposite_dir, possession_arrow = opposite_dir
-            ))
-            handle_clump(new_state, evs)
-          case _ =>
-            (state, evs) //(do nothing, wait for next clump)
-        }
-        ctx.stateChange(new_state, enriched_evs)
-
-      case StateEvent.Next(ctx, state, ConcurrentClump(evs)) => // Standard processing
-        val (new_state, enriched_evs) = handle_clump(state, evs)
-        ctx.stateChange(new_state, enriched_evs)
-
-      case StateEvent.Complete(ctx, _) => //(no additional processing when element list complete)
-        ctx.noChange
-
-    }) match {
-      case FoldStateComplete(_, events) =>
-        events
-    }
-    */
 
   } //(end calculate_possessions)
 }

--- a/src/main/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/PossessionUtils.scala
+++ b/src/main/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/PossessionUtils.scala
@@ -27,12 +27,15 @@ trait PossessionUtils {
     team: Int, opponent: Int,
     direction: Direction.Value,
     possession_arrow: Direction.Value, //(who gets possession next game break)
-    possession_unclear: Boolean
-  )
+    status: PossState.Status.Value
+  ) {
+    def unclear: Boolean = status == PossState.Status.Unclear
+    def broken: Boolean = status == PossState.Status.Error
+  }
   protected object PossState {
     /** Starting state */
     def init: PossState  = PossState(
-      0, 0, Direction.Init, Direction.Init, false
+      0, 0, Direction.Init, Direction.Init, Status.Normal
     )
     /** Handles concurrency issues with the input data */
     case class ConcurrencyState(
@@ -42,6 +45,9 @@ trait PossessionUtils {
       /** Starting state */
       def init: ConcurrencyState = ConcurrencyState(-1.0)
     }
+    object Status extends Enumeration {
+      val Normal, Unclear, Error = Value
+    }
   }
 
   protected case class ConcurrentClump(evs: List[Model.PlayByPlayEvent])
@@ -49,6 +55,7 @@ trait PossessionUtils {
   protected sealed trait PossessionStatus
   protected case object PossessionArrowSwitch extends PossessionStatus
   protected case object PossessionUnclear extends PossessionStatus
+  protected case object PossessionError extends PossessionStatus
   protected case object PossessionContinues extends PossessionStatus
   protected case class PossessionEnd(last_clump: Boolean = false) extends PossessionStatus
 
@@ -100,6 +107,13 @@ trait PossessionUtils {
     ))
   }
 
+  /** Manages splitting stream into concurrent chunks and then combining them */
+  protected val concurrent_event_handler = Clumper(
+    PossState.ConcurrencyState.init,
+    check_for_concurrent_event _,
+    rearrange_concurrent_event _
+  )
+
   /** Figure out who has possession to start the game */
   protected def first_possession_status(evs: List[Model.PlayByPlayEvent]): Option[Direction.Value] = {
     evs.collect {
@@ -120,9 +134,14 @@ trait PossessionUtils {
     evs: List[Model.PlayByPlayEvent]
   ): PossessionStatus =
   {
-    val dir = state.direction
-    val defendingTeam = PossessionEvent(dir).DefendingTeam
-    val attackingTeam = PossessionEvent(dir).AttackingTeam
+    val defendingTeam = PossessionEvent(state.direction).DefendingTeam
+    val attackingTeam = PossessionEvent(state.direction).AttackingTeam
+
+    /** Error out if the possession information is inconsistent with events */
+    def invalid_possession_state(evs: List[Model.PlayByPlayEvent]): Boolean = evs.collect {
+      case attackingTeam(EventUtils.ParseCommonDefensiveEvent(_)) => ()
+      case defendingTeam(EventUtils.ParseCommonOffensiveEvent(_)) => ()
+    }.nonEmpty
 
     /** This is the highest prio .. if the defending team rebounds it, they now have possession */
     def defensive_rebound(evs: List[Model.PlayByPlayEvent]): Boolean = evs.collect {
@@ -166,19 +185,19 @@ trait PossessionUtils {
       case _: Model.MiscGameBreak => ()
     }.nonEmpty
 
-    //TODO: error on inconsistencies rather than silently give the wrong possession count
-
     evs match {
+      case _ if invalid_possession_state(evs) => PossessionError
+
       case _ if end_of_period(evs) => PossessionArrowSwitch
 
       case _ if defensive_rebound(evs) => PossessionEnd(last_clump = true)
 
-      case _ if state.possession_unclear && !offensive_rebound(evs) => PossessionEnd(last_clump = true)
+      case _ if state.unclear && !offensive_rebound(evs) => PossessionEnd(last_clump = true)
         //(see the case that generates PossessionUnclear, below)
 
       case _ if offensive_turnover(evs) => PossessionEnd()
 
-      case _ if technical_foul(evs) && (fts_some_missed(evs) || fts_some_made(evs)) => PossessionContinues
+      case _ if technical_foul(evs) => PossessionContinues
         //(if the defending team is called for a technical, the offensive team will get the ball back)
 
       case _ if made_shot(evs) && missed_and_one(evs) => PossessionContinues //(wait for the rebound)
@@ -214,12 +233,12 @@ trait PossessionUtils {
       if (state.direction == Direction.Team) {
         state.copy(
           opponent = state.opponent + 1, direction = Direction.Opponent,
-          possession_unclear = false
+          status = PossState.Status.Normal
         )
       } else { //(must be Opponent, not Init, by construction)
         state.copy(
           team = state.team + 1, direction = Direction.Team,
-          possession_unclear = false
+          status = PossState.Status.Normal
         )
       }
     }
@@ -228,6 +247,12 @@ trait PossessionUtils {
     def handle_clump(
       state: PossState, evs: List[Model.PlayByPlayEvent]
     ): (PossState, List[Model.PlayByPlayEvent]) = clump_possession_status(state, evs) match {
+
+      case PossessionError =>
+        val new_state = state.copy(status = PossState.Status.Error)
+        val dummy_event = Model.OtherTeamEvent(0.0, Game.Score(0, 0), 0, "00:00,0-0,POSSESSION_STATE_ERROR")
+        (new_state, dummy_event :: evs)
+
       case PossessionArrowSwitch =>
         val new_state = switch_state(state).copy(
           direction = state.possession_arrow,
@@ -245,22 +270,19 @@ trait PossessionUtils {
         (new_state, evs.map(ev => enrich(state, ev)))
         //(use the old stqte because it's the _next_ clump that belongs to the update possession count)
       case PossessionUnclear =>
-        (state.copy(possession_unclear = true), evs.map(ev => enrich(state, ev)))
+        (state.copy(status = PossState.Status.Unclear), evs.map(ev => enrich(state, ev)))
       case PossessionContinues =>
-        (state.copy(possession_unclear = false), evs.map(ev => enrich(state, ev)))
+        (state.copy(status = PossState.Status.Normal), evs.map(ev => enrich(state, ev)))
     }
 
-    /** Manages splitting stream into concurrent chunks and then combining them */
-    val concurrent_event_handler = Clumper(
-      PossState.ConcurrencyState.init,
-      check_for_concurrent_event _,
-      rearrange_concurrent_event _
-    )
-
-    val clumped_events = raw_events.map(ev => ConcurrentClump(List(ev)))
+    val clumped_events = raw_events.map(ev => ConcurrentClump(ev :: Nil))
     (StateUtils.foldLeft(
       clumped_events, PossState.init, classOf[Model.PlayByPlayEvent], concurrent_event_handler
     ) {
+      case StateEvent.Next(ctx, state, ConcurrentClump(evs)) if state.broken =>
+        // An error occurred so we're going to stop calculate possessions for this game
+        ctx.stateChange(state, evs)
+
       case StateEvent.Next(ctx, state, ConcurrentClump(evs)) if state.direction == Direction.Init =>
         // First state, who has the first possession?
         val (new_state, enriched_evs) = first_possession_status(evs) match {

--- a/src/main/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/PossessionUtils.scala
+++ b/src/main/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/PossessionUtils.scala
@@ -194,6 +194,7 @@ trait PossessionUtils {
 
       case _ if state.unclear && !offensive_rebound(evs) => PossessionEnd(last_clump = true)
         //(see the case that generates PossessionUnclear, below)
+//TODO: also need to handle a foul on the rebound? need to see what that counts as 
 
       case _ if offensive_turnover(evs) => PossessionEnd()
 

--- a/src/main/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/PossessionUtils.scala
+++ b/src/main/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/PossessionUtils.scala
@@ -10,10 +10,8 @@ trait PossessionUtils {
   import ExtractorUtils._
   import StateUtils.StateTypes._
 
-//TODO: handle jump ball, switches the possession arrow....
-
   /** Useful scriptlet for checking results
-  // Show results (checl)
+  // Show results
   l.groupBy(t => (t.opponent, t.location_type)).mapValues(
     _.foldLeft((0,0))
     { (acc, v) => (acc._1 + v.team_stats.num_possessions,acc._2 + v.opponent_stats.num_possessions) }
@@ -21,15 +19,6 @@ trait PossessionUtils {
   // Compare to previous results
   (x1 zip x2).map { case (k, v) => k._1 -> (k._2._1 - v._2._1, k._2._2 - v._2._2) }
   */
-
-/** Problems:
-
-Delaware game:
-00:00:10		27-44	Jalen Smith, 3pt jumpshot fromturnover missed
-00:00:10		27-44	Team, rebound offensivedeadball
-I do always filter these out, but I thought I found some cases where they were relevant .. need to search
-
-*/
 
   // Lots of data modelling:
 
@@ -39,14 +28,14 @@ I do always filter these out, but I thought I found some cases where they were r
   }
   /** State for building possession events */
   protected case class PossState(
-    team_stats: StatsFragment,
-    opponent_stats: StatsFragment,
+    team_stats: PossCalcFragment,
+    opponent_stats: PossCalcFragment,
     prev_clump: ConcurrentClump
   )
   protected object PossState {
     /** Starting state */
     def init: PossState  = PossState(
-      StatsFragment(), StatsFragment(), ConcurrentClump(Nil)
+      PossCalcFragment(), PossCalcFragment(), ConcurrentClump(Nil)
     )
     /** Handles concurrency issues with the input data */
     case class ConcurrencyState(
@@ -58,39 +47,39 @@ I do always filter these out, but I thought I found some cases where they were r
     }
   }
 
-  protected case class ConcurrentClump(evs: List[Model.PlayByPlayEvent])
+  protected case class ConcurrentClump(evs: List[LineupEvent.RawGameEvent])
 
   protected case class PossessionEvent(dir: Direction.Value) {
     /** The team in possession */
     object AttackingTeam {
-      def unapply(x: Model.MiscGameEvent): Option[String] = x match {
-        case Model.OtherTeamEvent(_, _, _, event_str) if dir == Direction.Team => Some(event_str)
-        case Model.OtherOpponentEvent(_, _, _, event_str) if dir == Direction.Opponent => Some(event_str)
+      def unapply(x: LineupEvent.RawGameEvent): Option[String] = x match {
+        case LineupEvent.RawGameEvent.Team(event_str) if dir == Direction.Team => Some(event_str)
+        case LineupEvent.RawGameEvent.Opponent(event_str) if dir == Direction.Opponent => Some(event_str)
         case _ => None
       }
     }
     /** The team not in possession */
     object DefendingTeam {
-      def unapply(x: Model.MiscGameEvent): Option[String] = x match {
-        case Model.OtherTeamEvent(_, _, _, event_str) if dir == Direction.Opponent => Some(event_str)
-        case Model.OtherOpponentEvent(_, _, _, event_str) if dir == Direction.Team => Some(event_str)
+      def unapply(x: LineupEvent.RawGameEvent): Option[String] = x match {
+        case LineupEvent.RawGameEvent.Team(event_str) if dir == Direction.Opponent => Some(event_str)
+        case LineupEvent.RawGameEvent.Opponent(event_str) if dir == Direction.Team => Some(event_str)
         case _ => None
       }
     }
   }
 
   /** Maintains stats needed to calculate possessions for each lineup event */
-  protected case class StatsFragment(
+  case class PossCalcFragment(
     shots_made_or_missed: Int = 0,
     liveball_orbs: Int = 0,
     actual_deadball_orbs: Int = 0,
     ft_events: Int = 0,
     ignored_and_ones: Int = 0,
-    turnovers: Int = 0,
     bad_fouls: Int = 0,
-    offsetting_bad_fouls: Int = 0
+    offsetting_bad_fouls: Int = 0,
+    turnovers: Int = 0
   ) {
-    def sum(rhs: StatsFragment) = this.copy(
+    def sum(rhs: PossCalcFragment) = this.copy(
       shots_made_or_missed = this.shots_made_or_missed + rhs.shots_made_or_missed,
       liveball_orbs = this.liveball_orbs + rhs.liveball_orbs,
       actual_deadball_orbs = this.actual_deadball_orbs + rhs.actual_deadball_orbs,
@@ -108,7 +97,7 @@ I do always filter these out, but I thought I found some cases where they were r
       s"total=[$total_poss] = " +
       s"shots=[$shots_made_or_missed] - (orbs=[$liveball_orbs] + db_orbs=[$actual_deadball_orbs]) + " +
       s"(ft_sets=[$ft_events] - techs=[$bad_fouls]) + to=[$turnovers]" +
-      s"{ +1s=[$ignored_and_ones] offsetting_techs=[$offsetting_bad_fouls] }"
+      s" { +1s=[$ignored_and_ones] offset_techs=[$offsetting_bad_fouls] }"
     }
   }
 
@@ -128,13 +117,22 @@ I do always filter these out, but I thought I found some cases where they were r
 
   TODO: longer term need a context of nearby events, though this wouldn't have helped here
   */
-  def calculate_stats(clump: List[Model.PlayByPlayEvent], dir: Direction.Value): StatsFragment = {
+  protected def calculate_stats(
+    clump: ConcurrentClump, prev: ConcurrentClump, dir: Direction.Value
+  ): PossCalcFragment = {
     val attackingTeam = PossessionEvent(dir).AttackingTeam
     val defendingTeam = PossessionEvent(dir).DefendingTeam
 
-    val ft_event_this_clump: Boolean = clump.collect {
-      case attackingTeam(EventUtils.ParseFreeThrowMade(_)) => ()
-      case attackingTeam(EventUtils.ParseFreeThrowMissed(_)) => ()
+    /** Examples: have seen a spot when FTs aren't concurrent:
+    11:02:00		45-37	Connor McCaffery, freethrow 1of2 2ndchance;fastbreak made
+    10:56:00	Ricky Lindo Jr., substitution out	45-37
+    10:56:00	Darryl Morsell, substitution in	45-37
+    10:44:00		45-38	Connor McCaffery, freethrow 2of2 2ndchance;fastbreak made
+//TODO: with new format can handle this by looking for 1of[23]
+    */
+
+    val ft_event_this_clump: Boolean = clump.evs.collect {
+      case attackingTeam(EventUtils.ParseFreeThrowEvent(_)) => ()
     }.nonEmpty
 
     /** Examples:
@@ -161,17 +159,30 @@ I do always filter these out, but I thought I found some cases where they were r
     00:50:40		70-65	Bruno Fernando, rebound defensive
     00:50:40		70-65	Aaron Wiggins, foul personal oneandone
 
-    TODO; old format
+    The detection won't be perfect, we're going to look for a free throw that is
+    (concurrent with a made shot) OR
+    the previous clump had a made shot for direction AND not in the other direction
     */
-    val and_one: Int = clump.collect {
-      //TODO: fix "and one" detection
+    def combined_events_iterator = (clump.evs.iterator ++ prev.evs.iterator)
+    val and_one: Int = if (
+        (clump.evs.collect { //(there's exactly 1 FT)...
+          case attackingTeam(EventUtils.ParseFreeThrowMade(_)) => ()
+          case attackingTeam(EventUtils.ParseFreeThrowMissed(_)) => ()
+        }.size == 1) &&
+          (clump.evs.collect { //...(either concurrent with a made shot)...
+            case attackingTeam(EventUtils.ParseShotMade(_)) => ()
+          }.nonEmpty ||
+            (prev.evs.collect { //...(or the last clump, but...
+              case attackingTeam(EventUtils.ParseShotMade(_)) => ()
+            }.nonEmpty &&
+            prev.evs.collect { // ... in that clump the opponent _didn't_ have possession)
+              case defendingTeam(EventUtils.ParseOffensiveEvent(_)) => ()
+            }.isEmpty)
+          )
+        ) 1 else 0
 
-      case attackingTeam(EventUtils.ParseFreeThrowMade(_)) => ()
-      case attackingTeam(EventUtils.ParseFreeThrowMissed(_)) => ()
-    }.size
-
-    val filtered_clump = clump.filter {
-      case attackingTeam(EventUtils.ParseTeamDeadballRebound(_)) => false
+    val filtered_clump = clump.evs.filter {
+      case attackingTeam(EventUtils.ParseDeadballRebound(_)) => false
       case _ => true
     }
 
@@ -216,7 +227,7 @@ I do always filter these out, but I thought I found some cases where they were r
         07:28:00	Kevin Anderson, foul personal flagrant1	51-61
         07:10:00		51-61	Anthony Cowan, 2pt jumpshot missed
 
-  TODO; old format
+        Not much that we can do with old format because fouls just appear as normal
     */
 
     val offsetting_tech: Int = if (filtered_clump.collect {
@@ -231,7 +242,7 @@ I do always filter these out, but I thought I found some cases where they were r
       case defendingTeam(EventUtils.ParseFlagrantFoul(_)) => ()
     }.nonEmpty) 1 else 0
 
-    val techs_or_flagrant: Int = (if (filtered_clump.collect {
+    val tech_or_flagrant: Int = (if (filtered_clump.collect {
       case defendingTeam(EventUtils.ParseTechnicalFoul(_)) => ()
       case defendingTeam(EventUtils.ParseFlagrantFoul(_)) => ()
     }.nonEmpty) 1 else 0) - offsetting_tech - offsetting_flagrant
@@ -261,25 +272,49 @@ I do always filter these out, but I thought I found some cases where they were r
     09:51:00    Darian Bryant, substitution in    45-58
     09:49:00        45-58    Jalen Smith, turnover badpass
 
-TODO; old format (Don't think you get O vs D in the case)
+    Ignorable rebounds Can also be in prev clump
+    07:49:00		51-60	Darryl Morsell, freethrow 1of2 fastbreak;fromturnover missed
+    ...
+    07:45:00		51-61	Team, rebound offensivedeadball
+
+    This won't be perfect, but we'll ignore any deadball rebounds if the current
+    or previous clumps involved missed free throws
+    (otherwise it gets complicated with techs and 1-and-1s)
+
+    Also only works with new format
     */
-    val real_deadball_orbs = clump.collect {
-//TODO
-      case attackingTeam(EventUtils.ParseOffensiveRebound(_)) => ()
-    }.size
+
+    val recent_dead_ft_misses = List(clump.evs, prev.evs).map { evs =>
+      evs.collect {
+        case ev @ attackingTeam(EventUtils.ParseFreeThrowMade(_)) => ev
+        case ev @ attackingTeam(EventUtils.ParseFreeThrowMissed(_)) => ev
+      }.sortBy(ev => ev.score_str).reverse match { // reverse => highest first
+//TODO: this will be wrong when a FT moves from 9->10 or 99->100
+        case fts => fts.drop(1).collect {
+          case ev @ attackingTeam(EventUtils.ParseFreeThrowMissed(_)) => ev
+        }.size
+      }
+    }.sum
+
+    // this can be wrong if the _prev_ clump had a technical/flagrant, we'll live with that
+    val real_deadball_orbs =
+      if ((recent_dead_ft_misses == 0) && (tech_or_flagrant == 0)) clump.evs.collect {
+        case ev @ attackingTeam(EventUtils.ParseOffensiveDeadballRebound(_))
+          if !ev.info.startsWith("00:00") //(see spurious deadball rebounds at the end of the period)
+        => ()
+      }.size else 0
 
     val turnovers = filtered_clump.collect {
       case attackingTeam(EventUtils.ParseTurnover(_)) => ()
     }.size
 
-    StatsFragment(
+    PossCalcFragment(
       shots_made_or_missed,
       orbs, real_deadball_orbs,
       ft_event, and_one,
-      techs_or_flagrant, offsetting_tech + offsetting_flagrant,
+      tech_or_flagrant, offsetting_tech + offsetting_flagrant,
       turnovers
     )
-
   }
 
   /** Identify concurrent events (easy) */
@@ -289,9 +324,11 @@ TODO; old format (Don't think you get O vs D in the case)
     case Clumper.Event(_, cs, Nil, ConcurrentClump(ev :: _)) =>
       //(first event always gens a clump, possibly of size 1)
       (cs.copy(last_min = ev.min), true)
-    case Clumper.Event(_, cs, _, ConcurrentClump((ev: Model.MiscGameBreak) :: _)) =>
+
+    //case Clumper.Event(_, cs, _, ConcurrentClump((ev: Model.MiscGameBreak) :: _)) =>
+      //(the equivalent to this doesn't exist in lineups)
       // Game breaks can never be part of a clump
-      (cs.copy(last_min = -1.0), false)
+      //(cs.copy(last_min = -1.0), false)
     case Clumper.Event(_, cs, _, ConcurrentClump(ev :: _)) if ev.min == cs.last_min =>
       (cs, true)
     case Clumper.Event(_, cs, _, ConcurrentClump(ev :: _)) =>
@@ -305,7 +342,7 @@ TODO; old format (Don't think you get O vs D in the case)
     s: PossState, cs: PossState.ConcurrencyState, reverse_clump: List[ConcurrentClump]
   ): List[ConcurrentClump] = {
     val raw_list =
-      reverse_clump.foldLeft(List[Model.PlayByPlayEvent]()) { (acc, v) => v.evs ++ acc } //(re-reverses it)
+      reverse_clump.foldLeft(List[LineupEvent.RawGameEvent]()) { (acc, v) => v.evs ++ acc } //(re-reverses it)
     List(ConcurrentClump(
       raw_list
     ))
@@ -320,41 +357,45 @@ TODO; old format (Don't think you get O vs D in the case)
 
   /** Returns team and opponent possessions based on the raw event data */
   def calculate_possessions(
-    raw_events: Seq[Model.PlayByPlayEvent]
-  ): List[Model.PlayByPlayEvent] =
+    raw_events: Seq[LineupEvent.RawGameEvent],
+    previous_events: Seq[LineupEvent.RawGameEvent]
+  ): (PossCalcFragment, PossCalcFragment) =
   {
+    val show_end_of_calcs = true
     def summarize_state(label: String, state: PossState): Unit = {
       println(s"--------$label------------")
       println(s"[${state.team_stats.summary}]")
       println(s"[${state.opponent_stats.summary}]")
-      println("------------------------")
+      println("-------------------------")
     }
 
     val clumped_events = raw_events.map(ev => ConcurrentClump(ev :: Nil))
     StateUtils.foldLeft(
-      clumped_events, PossState.init, classOf[Model.PlayByPlayEvent], concurrent_event_handler
+      clumped_events, PossState.init, classOf[LineupEvent.RawGameEvent], concurrent_event_handler
     ) {
       case StateEvent.Next(ctx, state, clump @ ConcurrentClump(evs)) =>
         val new_state = state.copy(
-          team_stats = state.team_stats.sum(calculate_stats(evs, Direction.Team)),
-          opponent_stats = state.opponent_stats.sum(calculate_stats(evs, Direction.Opponent)),
+          team_stats = state.team_stats.sum(
+            calculate_stats(clump, state.prev_clump, Direction.Team)
+          ),
+          opponent_stats = state.opponent_stats.sum(
+            calculate_stats(clump, state.prev_clump, Direction.Opponent)
+          ),
           prev_clump = clump
         )
-/**///display
-        if (evs.collect { case _: Model.GameBreakEvent => true }.nonEmpty) {
-          summarize_state("HALF", state)
-        }
         ctx.stateChange(new_state)
 
       case StateEvent.Complete(ctx, state) => //(no additional processing when element list complete)
-/**///display
-        summarize_state("END-", state)
+        if (show_end_of_calcs) {
+          summarize_state("-END-", state)
+        }
         ctx.noChange
 
+    } match {
+      case FoldStateComplete.State(state) => (state.team_stats, state.opponent_stats)
     }
-    raw_events.toList
-
 
   } //(end calculate_possessions)
+
 }
 object PossessionUtils extends PossessionUtils

--- a/src/main/scala/org/piggottfamily/utils/StateUtils.scala
+++ b/src/main/scala/org/piggottfamily/utils/StateUtils.scala
@@ -81,7 +81,6 @@ object StateUtils {
         (), (_: Clumper.Event[S, Unit, A]) => ((), false), (_: S, _: Unit, as: List[A]) => as.reverse
       )
     }
-
   }
   import StateTypes._
 

--- a/src/main/scala/org/piggottfamily/utils/StateUtils.scala
+++ b/src/main/scala/org/piggottfamily/utils/StateUtils.scala
@@ -173,9 +173,9 @@ object StateUtils {
     case NoChange() => acc
     case StateChange(new_s) => acc.copy(s = new_s)
     case ConstantState(b) => acc.copy(bs = b :: acc.bs)
-    case ConstantStateMulti(bs) => acc.copy(bs = bs ++ acc.bs)
+    case ConstantStateMulti(bs) => acc.copy(bs = bs.reverse ++ acc.bs)
     case AllChange(new_s, b) => acc.copy(s = new_s, bs = b :: acc.bs)
-    case AllChangeMulti(new_s, bs) => acc.copy(s = new_s, bs = bs ++ acc.bs)
+    case AllChangeMulti(new_s, bs) => acc.copy(s = new_s, bs = bs.reverse ++ acc.bs)
   }
 
   //TODO scanLeft, which returns the same "list" type as input together with an incremental view of the state

--- a/src/test/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/EventUtilsTests.scala
+++ b/src/test/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/EventUtilsTests.scala
@@ -53,6 +53,8 @@ object EventUtilsTests extends TestSuite {
         "08:44:00,20-23,Team, rebound offensive team" ::
         "08:44:00,20-23,SMITH,JALEN Offensive Rebound" ::
         "08:44:00,20-23,HARRAR,JOHN Defensive Rebound" ::
+        "04:33,46-45,TEAM Deadball Rebound" ::
+        "04:28:0,52-59,Team, rebound offensivedeadball" ::
         Nil
 
       val free_throw_made_test_cases =
@@ -61,7 +63,11 @@ object EventUtilsTests extends TestSuite {
         Nil
 
       val free_throw_missed_test_cases =
-        "08:44:00,20-23,Kevin Anderson, freethrow 1of2 missed" ::
+        "08:44:00,20-23,Kevin Anderson1, freethrow 1of2 missed" ::
+        "08:44:00,20-23,Kevin Anderson2, freethrow 2of2 missed" ::
+        "08:44:00,20-23,Kevin Anderson3, freethrow 1of3 missed" ::
+        "08:44:00,20-23,Kevin Anderson4, freethrow 2of3 missed" ::
+        "08:44:00,20-23,Kevin Anderson5, freethrow 3of3 missed" ::
         "08:44:00,20-23,DREAD,MYLES missed Free Throw" ::
         Nil
 
@@ -151,7 +157,17 @@ object EventUtilsTests extends TestSuite {
           case EventUtils.ParseRebound(name) => name
         }) {
           case List(
-            "Darryl Morsell", "Jalen Smith", "Team", "SMITH,JALEN", "HARRAR,JOHN"
+            "Darryl Morsell", "Jalen Smith", "Team", "SMITH,JALEN", "HARRAR,JOHN", "TEAM", "Team"
+          ) =>
+        }
+      }
+      // (deadball)
+      "ParseTeamDeadballRebound" - {
+        TestUtils.inside(all_test_cases.collect {
+          case EventUtils.ParseTeamDeadballRebound(name) => name
+        }) {
+          case List(
+            "TEAM", "Team"
           ) =>
         }
       }
@@ -171,7 +187,17 @@ object EventUtilsTests extends TestSuite {
           case EventUtils.ParseFreeThrowMissed(name) => name
         }) {
           case List(
-            "Kevin Anderson", "DREAD,MYLES"
+            "Kevin Anderson1", "Kevin Anderson2", "Kevin Anderson3", "Kevin Anderson4",
+            "Kevin Anderson5", "DREAD,MYLES"
+          ) =>
+        }
+      }
+      "ParseMiddleFreeThrowMissed" - {
+        TestUtils.inside(all_test_cases.collect {
+          case EventUtils.ParseMiddleFreeThrowMissed(name) => name
+        }) {
+          case List(
+            "Kevin Anderson1", "Kevin Anderson3", "Kevin Anderson4",
           ) =>
         }
       }

--- a/src/test/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/EventUtilsTests.scala
+++ b/src/test/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/EventUtilsTests.scala
@@ -24,34 +24,34 @@ object EventUtilsTests extends TestSuite {
         Nil
 
       val shot_made_test_cases =
-        "08:44:00,20-23,Bruno Fernando, 2pt dunk 2ndchance;pointsinthepaint made" ::
-        "08:44:00,20-23,Bruno Fernando, 2pt alleyoop pointsinthepaint made" ::
+        "08:44:00,20-23,Bruno Fernando1, 2pt dunk 2ndchance;pointsinthepaint made" ::
+        "08:44:00,20-23,Bruno Fernando2, 2pt alleyoop pointsinthepaint made" ::
         "08:44:00,20-23,WATKINS,MIKE made Dunk" ::
         "08:44:00,20-23,Jalen Smith, 2pt layup 2ndchance;pointsinthepaint made" ::
         "08:44:00,20-23,BOLTON,RASIR made Layup" ::
         "08:44:00,20-23,STEVENS,LAMAR made Tip In" ::
         "08:44:00,20-23,Anthony Cowan, 2pt jumpshot fromturnover;fastbreak made" ::
-        "08:44:00,20-23,STEVENS,LAMAR made Two Point Jumper" ::
+        "08:44:00,20-23,STEVENS,LAMAR2 made Two Point Jumper" ::
         "08:44:00,20-23,Eric Ayala, 3pt jumpshot made" ::
         "08:44:00,20-23,SMITH,JALEN made Three Point Jumper" ::
         Nil
 
       val shot_missed_test_cases =
-        "08:44:00,20-23,Bruno Fernando, 2pt dunk missed" ::
-        "08:44:00,20-23,WATKINS,MIKE missed Dunk" ::
+        "08:44:00,20-23,Bruno Fernando3, 2pt dunk missed" ::
+        "08:44:00,20-23,WATKINS,MIKE1 missed Dunk" ::
         "08:44:00,20-23,Eric Carter, 2pt layup missed" ::
         "08:44:00,20-23,TOMAIC,JOSHUA missed Layup" ::
         "08:44:00,20-23,Ricky Lindo Jr., 2pt jumpshot missed" ::
-        "08:44:00,20-23,SMITH,JALEN missed Two Point Jumper" ::
-        "08:44:00,20-23,Eric Ayala, 3pt jumpshot 2ndchance missed" ::
+        "08:44:00,20-23,SMITH,JALEN1 missed Two Point Jumper" ::
+        "08:44:00,20-23,Eric Ayala2, 3pt jumpshot 2ndchance missed" ::
         "08:44:00,20-23,DREAD,MYLES missed Three Point Jumper" ::
         Nil
 
       val rebound_test_cases =
         "08:44:00,20-23,Darryl Morsell, rebound defensive" ::
-        "08:44:00,20-23,Jalen Smith, rebound offensive" ::
+        "08:44:00,20-23,Jalen Smith1, rebound offensive" ::
         "08:44:00,20-23,Team, rebound offensive team" ::
-        "08:44:00,20-23,SMITH,JALEN Offensive Rebound" ::
+        "08:44:00,20-23,SMITH,JALEN2 Offensive Rebound" ::
         "08:44:00,20-23,HARRAR,JOHN Defensive Rebound" ::
         "04:33,46-45,TEAM Deadball Rebound" ::
         "04:28:0,52-59,Team, rebound offensivedeadball" ::
@@ -59,24 +59,28 @@ object EventUtilsTests extends TestSuite {
         Nil
 
       val free_throw_made_test_cases =
+        "08:44:00,20-23,Kevin Anderson0M, freethrow 1of1 made" ::
+        "08:44:00,20-23,Kevin Anderson1M, freethrow 1of2 made" ::
         "08:44:00,20-23,Kevin Anderson, freethrow 2of2 made" ::
-        "08:44:00,20-23,DREAD,MYLES made Free Throw" ::
+        "08:44:00,20-23,Kevin Anderson3M, freethrow 1of3 made" ::
+        "08:44:00,20-23,DREAD,MYLES1 made Free Throw" ::
         Nil
 
       val free_throw_missed_test_cases =
+        "08:44:00,20-23,Kevin Anderson0m, freethrow 1of1 missed" ::
         "08:44:00,20-23,Kevin Anderson1, freethrow 1of2 missed" ::
         "08:44:00,20-23,Kevin Anderson2, freethrow 2of2 missed" ::
         "08:44:00,20-23,Kevin Anderson3, freethrow 1of3 missed" ::
         "08:44:00,20-23,Kevin Anderson4, freethrow 2of3 missed" ::
         "08:44:00,20-23,Kevin Anderson5, freethrow 3of3 missed" ::
-        "08:44:00,20-23,DREAD,MYLES missed Free Throw" ::
+        "08:44:00,20-23,DREAD,MYLES2 missed Free Throw" ::
         Nil
 
       val turnover_test_cases =
-        "14:11:00,7-9,Bruno Fernando, turnover badpass" ::
+        "14:11:00,7-9,Bruno Fernando4, turnover badpass" ::
         "14:11:00,7-9,Joshua Tomaic, turnover lostball" ::
-        "14:11:00,7-9,Jalen Smith, turnover offensive" ::
-        "14:11:00,7-9,Kevin Anderson, turnover travel" ::
+        "14:11:00,7-9,Jalen Smith2, turnover offensive" ::
+        "14:11:00,7-9,Kevin Anderson6, turnover travel" ::
         "14:11:00,7-9,MORSELL,DARRYL Turnover" ::
         Nil
 
@@ -91,10 +95,12 @@ object EventUtilsTests extends TestSuite {
         Nil
 
       val foul_test_cases =
-        "13:36:00,7-9,Jalen Smith, foul personal shooting;2freethrow" ::
+        "10:00,51-60,TEAM Commits Foul" :: //(old style tech)
+        "13:36:00,7-9,Jalen Smith3, foul personal shooting;2freethrow" ::
         "10:00,51-60,MYKHAILIUK,SVI Commits Foul" ::
-        "06:43:00,55-79,Bruno Fernando, foul technical classa;2freethrow" ::
-        "02:28:00,27-38,Jalen Smith, foulon" ::
+        "06:43:00,55-79,Bruno Fernando5, foul technical classa;2freethrow" ::
+        "02:28:00,27-38,Jalen Smith4, foulon" ::
+        "03:42:00,10-10,Eric Carter1, foul personal flagrant1;2freethrow" ::
         Nil
 
       val all_test_cases = (
@@ -135,27 +141,29 @@ object EventUtilsTests extends TestSuite {
         }
       }
       // Shots
+      val shots_made = List(
+        "Bruno Fernando1", "Bruno Fernando2", "WATKINS,MIKE", "Jalen Smith",
+        "BOLTON,RASIR", "STEVENS,LAMAR", "Anthony Cowan", "STEVENS,LAMAR2",
+        "Eric Ayala", "SMITH,JALEN"
+      )
       "ParseShotMade" - {
         TestUtils.inside(all_test_cases.collect {
           case EventUtils.ParseShotMade(name) => name
         }) {
-          case List(
-            "Bruno Fernando", "Bruno Fernando", "WATKINS,MIKE", "Jalen Smith",
-            "BOLTON,RASIR", "STEVENS,LAMAR", "Anthony Cowan", "STEVENS,LAMAR",
-            "Eric Ayala", "SMITH,JALEN"
-          ) =>
+          case `shots_made` =>
         }
 
       }
+      val shots_missed = List(
+        "Bruno Fernando3", "WATKINS,MIKE1", "Eric Carter",
+        "TOMAIC,JOSHUA", "Ricky Lindo Jr.", "SMITH,JALEN1",
+        "Eric Ayala2", "DREAD,MYLES"
+      )
       "ParseShotMissed" - {
           TestUtils.inside(all_test_cases.collect {
             case EventUtils.ParseShotMissed(name) => name
           }) {
-            case List(
-              "Bruno Fernando", "WATKINS,MIKE", "Eric Carter",
-              "TOMAIC,JOSHUA", "Ricky Lindo Jr.", "SMITH,JALEN",
-              "Eric Ayala", "DREAD,MYLES"
-            ) =>
+            case `shots_missed` =>
           }
       }
 
@@ -165,18 +173,29 @@ object EventUtilsTests extends TestSuite {
           case EventUtils.ParseRebound(name) => name
         }) {
           case List(
-            "Darryl Morsell", "Jalen Smith", "Team", "SMITH,JALEN", "HARRAR,JOHN", "TEAM", "Team", "Team"
+            "Darryl Morsell", "Jalen Smith1", "Team", "SMITH,JALEN2", "HARRAR,JOHN", "TEAM", "Team", "Team"
           ) =>
         }
       }
       //(defensive)
+      "ParseOffensiveRebound" - {
+        TestUtils.inside(all_test_cases.collect {
+          case EventUtils.ParseOffensiveRebound(name) => name
+        }) {
+          case List(
+          "Jalen Smith1", "Team", "SMITH,JALEN2", "Team"
+          ) =>
+        }
+      }
+      //(defensive)
+      val drbs = List(
+        "Darryl Morsell", "HARRAR,JOHN", "Team"
+      )
       "ParseDefensiveRebound" - {
         TestUtils.inside(all_test_cases.collect {
           case EventUtils.ParseDefensiveRebound(name) => name
         }) {
-          case List(
-            "Darryl Morsell", "HARRAR,JOHN", "Team"
-          ) =>
+          case `drbs` =>
         }
       }
       // (deadball)
@@ -189,53 +208,86 @@ object EventUtilsTests extends TestSuite {
           ) =>
         }
       }
+      "ParseDeadballRebound" - {
+        TestUtils.inside(all_test_cases.collect {
+          case EventUtils.ParseOffensiveDeadballRebound(name) => name
+        }) {
+          case List(
+            "Team",
+          ) =>
+        }
+      }
 
       // Free throws
+      val fts_made = List(
+        "Kevin Anderson0M", "Kevin Anderson1M", "Kevin Anderson", "Kevin Anderson3M", "DREAD,MYLES1"
+      )
       "ParseFreeThrowMade" - {
         TestUtils.inside(all_test_cases.collect {
           case EventUtils.ParseFreeThrowMade(name) => name
         }) {
-          case List(
-            "Kevin Anderson", "DREAD,MYLES"
-          ) =>
+          case `fts_made` =>
         }
       }
+      val fts_missed = List(
+        "Kevin Anderson0m",
+        "Kevin Anderson1", "Kevin Anderson2", "Kevin Anderson3", "Kevin Anderson4",
+        "Kevin Anderson5", "DREAD,MYLES2"
+      )
       "ParseFreeThrowMissed" - {
         TestUtils.inside(all_test_cases.collect {
           case EventUtils.ParseFreeThrowMissed(name) => name
         }) {
+          case `fts_missed` =>
+        }
+      }
+      "ParseFreeThrowEvent" - {
+        TestUtils.inside(all_test_cases.collect {
+          case EventUtils.ParseFreeThrowEvent(name) => name
+        }) {
           case List(
-            "Kevin Anderson1", "Kevin Anderson2", "Kevin Anderson3", "Kevin Anderson4",
-            "Kevin Anderson5", "DREAD,MYLES"
+            "Kevin Anderson0M", "Kevin Anderson1M", "Kevin Anderson3M", "DREAD,MYLES1",
+            "Kevin Anderson0m", "Kevin Anderson1", "Kevin Anderson3", "DREAD,MYLES2"
           ) =>
+        }
+      }
+      val fts_attempt = fts_made ++ fts_missed
+      "ParseFreeThrowAttempt" - {
+        TestUtils.inside(all_test_cases.collect {
+          case EventUtils.ParseFreeThrowAttempt(name) => name
+        }) {
+          case `fts_attempt` =>
         }
       }
 
       // Turnovers
+      val turnovers = List(
+        "Bruno Fernando4", "Joshua Tomaic", "Jalen Smith2", "Kevin Anderson6", "MORSELL,DARRYL"
+      )
       "ParseTurnover" - {
         TestUtils.inside(all_test_cases.collect {
           case EventUtils.ParseTurnover(name) => name
         }) {
-          case List(
-            "Bruno Fernando", "Joshua Tomaic", "Jalen Smith", "Kevin Anderson", "MORSELL,DARRYL"
-          ) =>
+          case `turnovers` =>
         }
       }
 
       // Blocks
+      val blockers = List("Emmitt Williams", "LAYMAN,JAKE")
       "ParseShotBlocked" - {
         TestUtils.inside(all_test_cases.collect {
           case EventUtils.ParseShotBlocked(name) => name
         }) {
-          case List("Emmitt Williams", "LAYMAN,JAKE") =>
+          case `blockers` =>
         }
       }
       // Steals
+      val stealers = List("Jacob Cushing", "MASON III,FRANK")
       "ParseStolen" - {
         TestUtils.inside(all_test_cases.collect {
           case EventUtils.ParseStolen(name) => name
         }) {
-          case List("Jacob Cushing", "MASON III,FRANK") =>
+          case `stealers` =>
         }
       }
 
@@ -244,23 +296,63 @@ object EventUtilsTests extends TestSuite {
         TestUtils.inside(all_test_cases.collect {
           case EventUtils.ParsePersonalFoul(name) => name
         }) {
-          case List("Jalen Smith", "MYKHAILIUK,SVI") =>
+          case List("Jalen Smith3", "MYKHAILIUK,SVI", "Eric Carter1") =>
+        }
+      }
+      "ParseFlagrantFoul" - {
+        TestUtils.inside(all_test_cases.collect {
+          case EventUtils.ParseFlagrantFoul(name) => name
+        }) {
+          case List("Eric Carter1") =>
         }
       }
       "ParseTechnicalFoul" - {
         TestUtils.inside(all_test_cases.collect {
           case EventUtils.ParseTechnicalFoul(name) => name
         }) {
-          case List("Bruno Fernando") =>
+          case List("TEAM", "Bruno Fernando5") =>
         }
       }
       "ParseFoulInfo" - {
         TestUtils.inside(all_test_cases.collect {
           case EventUtils.ParseFoulInfo(name) => name
         }) {
-          case List("Jalen Smith") =>
+          case List("Jalen Smith4") =>
         }
       }
+      // combos
+      val offensive_actions = shots_made ++ shots_missed ++ fts_attempt ++ turnovers
+      "ParseOffensiveEvent" - {
+        TestUtils.inside(all_test_cases.collect {
+          case EventUtils.ParseOffensiveEvent(name) => name
+        }) {
+          case `offensive_actions` =>
+        }
+      }
+      val defensive_actions = blockers ++ stealers
+      "ParseDefensiveInfoEvent" - {
+        TestUtils.inside(all_test_cases.collect {
+          case EventUtils.ParseDefensiveInfoEvent(name) => name
+        }) {
+          case `defensive_actions` =>
+        }
+      }      
+      "ParseDefensiveActionEvent" - {
+        TestUtils.inside(all_test_cases.collect {
+          case EventUtils.ParseDefensiveActionEvent(name) => name
+        }) {
+          case `drbs` =>
+        }
+      }
+      val defensive_events = drbs ++ defensive_actions
+      "ParseDefensiveEvent" - {
+        TestUtils.inside(all_test_cases.collect {
+          case EventUtils.ParseDefensiveEvent(name) => name
+        }) {
+          case `defensive_events` =>
+        }
+      }
+
     }
   }
 }

--- a/src/test/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/EventUtilsTests.scala
+++ b/src/test/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/EventUtilsTests.scala
@@ -13,59 +13,217 @@ object EventUtilsTests extends TestSuite {
       //TODO: add time-parsing tests, though they are covered by the main test logic
       //TODO: add substitution tests, though they are covered by the main test logic
 
+      val jumpball_test_cases =
+        "19:58:00,0-0,Kavell Bigby-Williams, jumpball lost" ::
+        "19:58:00,0-0,Bruno Fernando, jumpball won" ::
+        Nil
+
+      val timeout_test_cases =
+        "04:04:00,26-33,Ignored, timeout short" ::
+        "00:21,59-62,IGNORED 30 Second Timeout" ::
+        Nil
+
+      val shot_made_test_cases =
+        "08:44:00,20-23,Bruno Fernando, 2pt dunk 2ndchance;pointsinthepaint made" ::
+        "08:44:00,20-23,Bruno Fernando, 2pt alleyoop pointsinthepaint made" ::
+        "08:44:00,20-23,WATKINS,MIKE made Dunk" ::
+        "08:44:00,20-23,Jalen Smith, 2pt layup 2ndchance;pointsinthepaint made" ::
+        "08:44:00,20-23,BOLTON,RASIR made Layup" ::
+        "08:44:00,20-23,STEVENS,LAMAR made Tip In" ::
+        "08:44:00,20-23,Anthony Cowan, 2pt jumpshot fromturnover;fastbreak made" ::
+        "08:44:00,20-23,STEVENS,LAMAR made Two Point Jumper" ::
+        "08:44:00,20-23,Eric Ayala, 3pt jumpshot made" ::
+        "08:44:00,20-23,SMITH,JALEN made Three Point Jumper" ::
+        Nil
+
+      val shot_missed_test_cases =
+        "08:44:00,20-23,Bruno Fernando, 2pt dunk missed" ::
+        "08:44:00,20-23,WATKINS,MIKE missed Dunk" ::
+        "08:44:00,20-23,Eric Carter, 2pt layup missed" ::
+        "08:44:00,20-23,TOMAIC,JOSHUA missed Layup" ::
+        "08:44:00,20-23,Ricky Lindo Jr., 2pt jumpshot missed" ::
+        "08:44:00,20-23,SMITH,JALEN missed Two Point Jumper" ::
+        "08:44:00,20-23,Eric Ayala, 3pt jumpshot 2ndchance missed" ::
+        "08:44:00,20-23,DREAD,MYLES missed Three Point Jumper" ::
+        Nil
+
+      val rebound_test_cases =
+        "08:44:00,20-23,Darryl Morsell, rebound defensive" ::
+        "08:44:00,20-23,Jalen Smith, rebound offensive" ::
+        "08:44:00,20-23,Team, rebound offensive team" ::
+        "08:44:00,20-23,SMITH,JALEN Offensive Rebound" ::
+        "08:44:00,20-23,HARRAR,JOHN Defensive Rebound" ::
+        Nil
+
+      val free_throw_made_test_cases =
+        "08:44:00,20-23,Kevin Anderson, freethrow 2of2 made" ::
+        "08:44:00,20-23,DREAD,MYLES made Free Throw" ::
+        Nil
+
+      val free_throw_missed_test_cases =
+        "08:44:00,20-23,Kevin Anderson, freethrow 1of2 missed" ::
+        "08:44:00,20-23,DREAD,MYLES missed Free Throw" ::
+        Nil
+
+      val turnover_test_cases =
+        "14:11:00,7-9,Bruno Fernando, turnover badpass" ::
+        "14:11:00,7-9,Joshua Tomaic, turnover lostball" ::
+        "14:11:00,7-9,Jalen Smith, turnover offensive" ::
+        "14:11:00,7-9,Kevin Anderson, turnover travel" ::
+        "14:11:00,7-9,MORSELL,DARRYL Turnover" ::
+        Nil
+
+      val blocked_test_cases =
+        "14:11:00,7-9,Emmitt Williams, block" ::
+        "04:53,55-69,LAYMAN,JAKE Blocked Shot" ::
+        Nil
+
+      val stolen_test_cases =
+        "08:44:00,20-23,Jacob Cushing, steal" ::
+        "05:10,55-68,MASON III,FRANK Steal" ::
+        Nil
+
+      val foul_test_cases =
+        "13:36:00,7-9,Jalen Smith, foul personal shooting;2freethrow" ::
+        "10:00,51-60,MYKHAILIUK,SVI Commits Foul" ::
+        "06:43:00,55-79,Bruno Fernando, foul technical classa;2freethrow" ::
+        "02:28:00,27-38,Jalen Smith, foulon" ::
+        Nil
+
+      val all_test_cases = (
+        jumpball_test_cases ++
+        timeout_test_cases ++
+        shot_made_test_cases ++
+        shot_missed_test_cases ++
+        rebound_test_cases ++
+        free_throw_made_test_cases ++
+        free_throw_missed_test_cases ++
+        turnover_test_cases ++
+        blocked_test_cases ++
+        stolen_test_cases ++
+        foul_test_cases
+      )
+
       // jumpball
       "ParseJumpballWonOrLost" - {
-        TestUtils.inside(Some("19:58:00,0-0,Kavell Bigby-Williams, jumpball lost")) {
-          case EventUtils.ParseJumpballWonOrLost("Kavell Bigby-Williams") =>
-        }
-        TestUtils.inside(Some("19:58:00,0-0,Bruno Fernando, jumpball won")) {
-          case EventUtils.ParseJumpballWonOrLost("Bruno Fernando") =>
+        TestUtils.inside(all_test_cases.collect {
+          case EventUtils.ParseJumpballWonOrLost(name) => name
+        }) {
+          case List("Kavell Bigby-Williams", "Bruno Fernando") =>
         }
       }
       // Timeout
       "ParseTimeout" - {
-        TestUtils.inside(Some("04:04:00,26-33,Ignored, timeout short")) {
-          case EventUtils.ParseTimeout("Team") =>
-        }
-        TestUtils.inside(Some("00:21,59-62,IGNORED 30 Second Timeout")) {
-          case EventUtils.ParseTimeout("TEAM") =>
+        TestUtils.inside(all_test_cases.collect {
+          case EventUtils.ParseTimeout(name) => name
+        }) {
+          case List("Team", "TEAM") =>
         }
       }
+      // Shots
+      "ParseShotMade" - {
+        TestUtils.inside(all_test_cases.collect {
+          case EventUtils.ParseShotMade(name) => name
+        }) {
+          case List(
+            "Bruno Fernando", "Bruno Fernando", "WATKINS,MIKE", "Jalen Smith",
+            "BOLTON,RASIR", "STEVENS,LAMAR", "Anthony Cowan", "STEVENS,LAMAR",
+            "Eric Ayala", "SMITH,JALEN"
+          ) =>
+        }
+
+      }
+      "ParseShotMissed" - {
+          TestUtils.inside(all_test_cases.collect {
+            case EventUtils.ParseShotMissed(name) => name
+          }) {
+            case List(
+              "Bruno Fernando", "WATKINS,MIKE", "Eric Carter",
+              "TOMAIC,JOSHUA", "Ricky Lindo Jr.", "SMITH,JALEN",
+              "Eric Ayala", "DREAD,MYLES"
+            ) =>
+          }
+      }
+
+      // Rebounds
+      "ParseRebound" - {
+        TestUtils.inside(all_test_cases.collect {
+          case EventUtils.ParseRebound(name) => name
+        }) {
+          case List(
+            "Darryl Morsell", "Jalen Smith", "Team", "SMITH,JALEN", "HARRAR,JOHN"
+          ) =>
+        }
+      }
+
+      // Free throws
+      "ParseFreeThrowMade" - {
+        TestUtils.inside(all_test_cases.collect {
+          case EventUtils.ParseFreeThrowMade(name) => name
+        }) {
+          case List(
+            "Kevin Anderson", "DREAD,MYLES"
+          ) =>
+        }
+      }
+      "ParseFreeThrowMissed" - {
+        TestUtils.inside(all_test_cases.collect {
+          case EventUtils.ParseFreeThrowMissed(name) => name
+        }) {
+          case List(
+            "Kevin Anderson", "DREAD,MYLES"
+          ) =>
+        }
+      }
+
+      // Turnovers
+      "ParseTurnover" - {
+        TestUtils.inside(all_test_cases.collect {
+          case EventUtils.ParseTurnover(name) => name
+        }) {
+          case List(
+            "Bruno Fernando", "Joshua Tomaic", "Jalen Smith", "Kevin Anderson", "MORSELL,DARRYL"
+          ) =>
+        }
+      }
+
       // Blocks
       "ParseShotBlocked" - {
-        TestUtils.inside(Some("14:11:00,7-9,Emmitt Williams, block")) {
-          case EventUtils.ParseShotBlocked("Emmitt Williams") =>
-        }
-        TestUtils.inside(Some("04:53,55-69,LAYMAN,JAKE Blocked Shot")) {
-          case EventUtils.ParseShotBlocked("LAYMAN,JAKE") =>
+        TestUtils.inside(all_test_cases.collect {
+          case EventUtils.ParseShotBlocked(name) => name
+        }) {
+          case List("Emmitt Williams", "LAYMAN,JAKE") =>
         }
       }
       // Steals
       "ParseStolen" - {
-        TestUtils.inside(Some("08:44:00,20-23,Jacob Cushing, steal")) {
-          case EventUtils.ParseStolen("Jacob Cushing") =>
-        }
-        TestUtils.inside(Some("05:10,55-68,MASON III,FRANK Steal")) {
-          case EventUtils.ParseStolen("MASON III,FRANK") =>
+        TestUtils.inside(all_test_cases.collect {
+          case EventUtils.ParseStolen(name) => name
+        }) {
+          case List("Jacob Cushing", "MASON III,FRANK") =>
         }
       }
+
       // Fouls
       "ParsePersonalFoul" - {
-        TestUtils.inside(Some("13:36:00,7-9,Jalen Smith, foul personal shooting;2freethrow")) {
-          case EventUtils.ParsePersonalFoul("Jalen Smith") =>
-        }
-        TestUtils.inside(Some("10:00,51-60,MYKHAILIUK,SVI Commits Foul")) {
-          case EventUtils.ParsePersonalFoul("MYKHAILIUK,SVI") =>
+        TestUtils.inside(all_test_cases.collect {
+          case EventUtils.ParsePersonalFoul(name) => name
+        }) {
+          case List("Jalen Smith", "MYKHAILIUK,SVI") =>
         }
       }
       "ParseTechnicalFoul" - {
-        TestUtils.inside(Some("06:43:00,55-79,Bruno Fernando, foul technical classa;2freethrow")) {
-          case EventUtils.ParseTechnicalFoul("Bruno Fernando") =>
+        TestUtils.inside(all_test_cases.collect {
+          case EventUtils.ParseTechnicalFoul(name) => name
+        }) {
+          case List("Bruno Fernando") =>
         }
       }
       "ParseFoulInfo" - {
-        TestUtils.inside(Some("02:28:00,27-38,Jalen Smith, foulon")) {
-          case EventUtils.ParseFoulInfo("Jalen Smith") =>
+        TestUtils.inside(all_test_cases.collect {
+          case EventUtils.ParseFoulInfo(name) => name
+        }) {
+          case List("Jalen Smith") =>
         }
       }
     }

--- a/src/test/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/EventUtilsTests.scala
+++ b/src/test/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/EventUtilsTests.scala
@@ -180,9 +180,9 @@ object EventUtilsTests extends TestSuite {
         }
       }
       // (deadball)
-      "ParseTeamDeadballRebound" - {
+      "ParseDeadballRebound" - {
         TestUtils.inside(all_test_cases.collect {
-          case EventUtils.ParseTeamDeadballRebound(name) => name
+          case EventUtils.ParseDeadballRebound(name) => name
         }) {
           case List(
             "TEAM", "Team", "Team"
@@ -207,15 +207,6 @@ object EventUtilsTests extends TestSuite {
           case List(
             "Kevin Anderson1", "Kevin Anderson2", "Kevin Anderson3", "Kevin Anderson4",
             "Kevin Anderson5", "DREAD,MYLES"
-          ) =>
-        }
-      }
-      "ParseMiddleFreeThrowMissed" - {
-        TestUtils.inside(all_test_cases.collect {
-          case EventUtils.ParseMiddleFreeThrowMissed(name) => name
-        }) {
-          case List(
-            "Kevin Anderson1", "Kevin Anderson3", "Kevin Anderson4",
           ) =>
         }
       }

--- a/src/test/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/EventUtilsTests.scala
+++ b/src/test/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/EventUtilsTests.scala
@@ -55,6 +55,7 @@ object EventUtilsTests extends TestSuite {
         "08:44:00,20-23,HARRAR,JOHN Defensive Rebound" ::
         "04:33,46-45,TEAM Deadball Rebound" ::
         "04:28:0,52-59,Team, rebound offensivedeadball" ::
+        "04:28:0,52-59,Team, rebound defensivedeadball" ::
         Nil
 
       val free_throw_made_test_cases =
@@ -118,6 +119,13 @@ object EventUtilsTests extends TestSuite {
           case List("Kavell Bigby-Williams", "Bruno Fernando") =>
         }
       }
+      "ParseJumpballWon" - {
+        TestUtils.inside(all_test_cases.collect {
+          case EventUtils.ParseJumpballWon(name) => name
+        }) {
+          case List("Bruno Fernando") =>
+        }
+      }
       // Timeout
       "ParseTimeout" - {
         TestUtils.inside(all_test_cases.collect {
@@ -157,7 +165,17 @@ object EventUtilsTests extends TestSuite {
           case EventUtils.ParseRebound(name) => name
         }) {
           case List(
-            "Darryl Morsell", "Jalen Smith", "Team", "SMITH,JALEN", "HARRAR,JOHN", "TEAM", "Team"
+            "Darryl Morsell", "Jalen Smith", "Team", "SMITH,JALEN", "HARRAR,JOHN", "TEAM", "Team", "Team"
+          ) =>
+        }
+      }
+      //(defensive)
+      "ParseDefensiveRebound" - {
+        TestUtils.inside(all_test_cases.collect {
+          case EventUtils.ParseDefensiveRebound(name) => name
+        }) {
+          case List(
+            "Darryl Morsell", "HARRAR,JOHN", "Team"
           ) =>
         }
       }
@@ -167,7 +185,7 @@ object EventUtilsTests extends TestSuite {
           case EventUtils.ParseTeamDeadballRebound(name) => name
         }) {
           case List(
-            "TEAM", "Team"
+            "TEAM", "Team", "Team"
           ) =>
         }
       }

--- a/src/test/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/ExtractorUtilsTests.scala
+++ b/src/test/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/ExtractorUtilsTests.scala
@@ -90,17 +90,21 @@ object ExtractorUtilsTests extends TestSuite {
           Model.OtherTeamEvent(0.4, Game.Score(0, 0), "[player2] pre-sub-4-ref-p2"),
           Model.OtherOpponentEvent(0.4, Game.Score(0, 0), "[player1] pre-sub-5-ignore-p1"),
           Model.OtherOpponentEvent(0.4, Game.Score(0, 0), "[player2] pre-sub-6-ignore-p2"),
+          Model.OtherTeamEvent(0.4, Game.Score(1, 0), "post-sub-1-no-ref"), //(confirm sorting works)
+          Model.OtherTeamEvent(0.4, Game.Score(0, 0), "11:11,0-0,misc_player, foulon"), //(check FT logic)
 
-          Model.SubInEvent(0.4, "player1"),
-          Model.OtherTeamEvent(0.4, Game.Score(0, 0), "middle-event"),
-          Model.SubOutEvent(0.4, "player2"),
+          Model.SubInEvent(0.4, Game.Score(0, 0), "player1"),
+          Model.OtherTeamEvent(0.4, Game.Score(0, 0), "middle-event-1"),
+          Model.OtherTeamEvent(0.4, Game.Score(1, 0), "middle-event-2"),
+          Model.SubOutEvent(0.4, Game.Score(0, 0), "player2"),
 
-          Model.OtherTeamEvent(0.4, Game.Score(0, 0), "post-sub-1-no-ref"),
-          Model.OtherOpponentEvent(0.4, Game.Score(0, 0), "post-sub-2-no-ref"),
-          Model.OtherTeamEvent(0.4, Game.Score(0, 0), "[player1] post-sub-3-ref-p1"),
-          Model.OtherTeamEvent(0.4, Game.Score(0, 0), "[player2] post-sub-4-ref-p2"),
-          Model.OtherOpponentEvent(0.4, Game.Score(0, 0), "[player1] post-sub-5-ignore-p1"),
-          Model.OtherOpponentEvent(0.4, Game.Score(0, 0), "[player2] post-sub-6-ignore-p2")
+          Model.OtherOpponentEvent(0.4, Game.Score(1, 0), "post-sub-2-no-ref"),
+          Model.OtherTeamEvent(0.4, Game.Score(1, 0), "[player1] post-sub-3-ref-p1"),
+          Model.OtherTeamEvent(0.4, Game.Score(1, 0), "[player2] post-sub-4-ref-p2"),
+          Model.OtherOpponentEvent(0.4, Game.Score(1, 0), "[player1] post-sub-5-ignore-p1"),
+          Model.OtherOpponentEvent(0.4, Game.Score(1, 0), "[player2] post-sub-6-ignore-p2"),
+          Model.OtherOpponentEvent(0.4, Game.Score(2, 0), "11:11,0-0,misc_player missed Free Throw"), //(ignored wrong direction)
+          Model.OtherTeamEvent(0.4, Game.Score(2, 0), "11:11,0-0,random_player missed Free Throw")
         )
 
         // (check trivial case )
@@ -120,15 +124,21 @@ object ExtractorUtilsTests extends TestSuite {
                 "pre-sub-1-no-ref", "pre-sub-2-no-ref",
                 "[player2] pre-sub-4-ref-p2",
                 "[player1] pre-sub-5-ignore-p1", "[player2] pre-sub-6-ignore-p2",
+                "11:11,0-0,misc_player, foulon",
+                "middle-event-1",
                 "[player2] post-sub-4-ref-p2",
+
+                "11:11,0-0,random_player missed Free Throw",
 
                 "player1", "player2",
 
-                "[player1] pre-sub-3-ref-p1", "middle-event",
+                "[player1] pre-sub-3-ref-p1",
+                "post-sub-1-no-ref", "middle-event-2", //(sorted to different positions)
 
-                "post-sub-1-no-ref", "post-sub-2-no-ref",
+                "post-sub-2-no-ref",
                 "[player1] post-sub-3-ref-p1",
-                "[player1] post-sub-5-ignore-p1", "[player2] post-sub-6-ignore-p2"
+                "[player1] post-sub-5-ignore-p1", "[player2] post-sub-6-ignore-p2",
+                "11:11,0-0,misc_player missed Free Throw"
               ) =>
             }
         }
@@ -165,46 +175,46 @@ object ExtractorUtilsTests extends TestSuite {
         val starting_lineup = box_lineup.copy(players = box_lineup.players.take(5))
         val test_events =
           // First event - sub immediately after game start
-          Model.SubInEvent(0.1, player6.id.name.toUpperCase) ::
+          Model.SubInEvent(0.1, Game.Score(0, 0), player6.id.name.toUpperCase) ::
           //(note player6 being all upper case for 2017- and lower case for 2018 is
           // important to this test because we latch format on the first name found)
-          Model.SubOutEvent(0.1, player1.id.name) ::
+          Model.SubOutEvent(0.1, Game.Score(0, 0), player1.id.name) ::
           Model.OtherTeamEvent(0.2, Game.Score(1, 0), "event1a") ::
           Model.OtherTeamEvent(0.2, Game.Score(2, 0), "event2a") ::
           // Second event
-          Model.SubInEvent(0.4, player1.id.name) ::
+          Model.SubInEvent(0.4, Game.Score(2, 0), player1.id.name) ::
           // confirm that all upper case names are returned to normal form:
-          Model.SubInEvent(0.4, player7.id.name.toUpperCase) ::
+          Model.SubInEvent(0.4, Game.Score(2, 0), player7.id.name.toUpperCase) ::
           // CHECK: we only care about "code" not "id":
-          Model.SubOutEvent(0.4, player2.id.name.toUpperCase + " ii") ::
-          Model.SubOutEvent(0.4, player4.id.name) ::
-          Model.OtherOpponentEvent(0.4, Game.Score(1, 1), "event1b") ::
-          Model.OtherOpponentEvent(0.4, Game.Score(1, 2), "event2b") ::
+          Model.SubOutEvent(0.4, Game.Score(2, 0), player2.id.name.toUpperCase + " ii") ::
+          Model.SubOutEvent(0.4, Game.Score(2, 0), player4.id.name) ::
+          Model.OtherOpponentEvent(0.4, Game.Score(2, 1), "event1b") ::
+          Model.OtherOpponentEvent(0.4, Game.Score(2, 2), "event2b") ::
           Model.OtherTeamEvent(0.4, Game.Score(3, 2), "event3a") ::
           Model.OtherTeamEvent(0.4, Game.Score(4, 2), "event4a") ::
           // Half time! (third event)
-          Model.GameBreakEvent(20.0) ::
+          Model.GameBreakEvent(20.0, Game.Score(4, 2)) ::
           // (subs happen immediately after break)
-          Model.SubOutEvent(20.0, player1.id.name) ::
+          Model.SubOutEvent(20.0, Game.Score(4, 2), player1.id.name) ::
           Model.OtherOpponentEvent(20.0, Game.Score(4, 2), "PlayerA Leaves Game") :: //opponents can sub too....
           Model.OtherOpponentEvent(20.0, Game.Score(4, 2), "PlayerB, substitution in") :: //(new format))
-          Model.SubInEvent(20.0, player6.id.name) ::
+          Model.SubInEvent(20.0, Game.Score(4, 2), player6.id.name) ::
           // Fourth event  - sub-on-sub action
-          Model.SubOutEvent(20.4, player2.id.name) ::
-          Model.SubOutEvent(20.4, player4.id.name) ::
-          Model.SubInEvent(20.4, player1.id.name) :: // check subs in any order
-          Model.SubInEvent(20.4, player7.id.name) ::
+          Model.SubOutEvent(20.4, Game.Score(4, 2), player2.id.name) ::
+          Model.SubOutEvent(20.4, Game.Score(4, 2), player4.id.name) ::
+          Model.SubInEvent(20.4, Game.Score(4, 2), player1.id.name) :: // check subs in any order
+          Model.SubInEvent(20.4, Game.Score(4, 2), player7.id.name) ::
           // Overtime! (first event)
-          Model.GameBreakEvent(40.0) ::
+          Model.GameBreakEvent(40.0, Game.Score(4, 2)) ::
           // Sixth event
           Model.OtherOpponentEvent(40.4, Game.Score(4, 3), "event3b") ::
           Model.OtherTeamEvent(40.4, Game.Score(5, 3), "event5a") ::
-          Model.SubInEvent(40.5, player6.id.name) ::
-          Model.SubOutEvent(40.5, player1.id.name) ::
+          Model.SubInEvent(40.5, Game.Score(5, 3), player6.id.name) ::
+          Model.SubOutEvent(40.5, Game.Score(5, 3), player1.id.name) ::
           Model.OtherTeamEvent(40.6, Game.Score(6, 3), "event6a") ::
           Model.OtherOpponentEvent(40.7, Game.Score(6, 4) , "event4b") ::
           // Fin (Seventh event)
-          Model.GameEndEvent(45.0) ::
+          Model.GameEndEvent(45.0, Game.Score(6, 4)) ::
           Nil
 
         List(my_team, my_team_2018).foreach { old_format_team =>
@@ -354,7 +364,7 @@ object ExtractorUtilsTests extends TestSuite {
 
         // Test format change for 2018, builds post-half lineup from pre-half lineup
         // (instead of starting lineup)
-        val new_format_test_events = Model.SubInEvent(0.1, player6.id.name) :: test_events.tail
+        val new_format_test_events = Model.SubInEvent(0.1, Game.Score(0, 0), player6.id.name) :: test_events.tail
 
         TestUtils.inside(build_partial_lineup_list(
           new_format_test_events.reverse.toIterator, box_lineup.copy(team = my_team_2018)

--- a/src/test/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/ExtractorUtilsTests.scala
+++ b/src/test/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/ExtractorUtilsTests.scala
@@ -84,23 +84,23 @@ object ExtractorUtilsTests extends TestSuite {
         //  but want to demonstrate all the branches of this somewhat complex sub function)
 
         val event_list @ (event_list_1 :: event_list_2 :: event_list_rest) = List(
-          Model.OtherTeamEvent(0.4, Game.Score(0, 0), "pre-sub-1-no-ref"),
-          Model.OtherOpponentEvent(0.4, Game.Score(0, 0), "pre-sub-2-no-ref"),
-          Model.OtherTeamEvent(0.4, Game.Score(0, 0), "[player1] pre-sub-3-ref-p1"),
-          Model.OtherTeamEvent(0.4, Game.Score(0, 0), "[player2] pre-sub-4-ref-p2"),
-          Model.OtherOpponentEvent(0.4, Game.Score(0, 0), "[player1] pre-sub-5-ignore-p1"),
-          Model.OtherOpponentEvent(0.4, Game.Score(0, 0), "[player2] pre-sub-6-ignore-p2"),
+          Model.OtherTeamEvent(0.4, Game.Score(0, 0), 1, "pre-sub-1-no-ref"),
+          Model.OtherOpponentEvent(0.4, Game.Score(0, 0), 1, "pre-sub-2-no-ref"),
+          Model.OtherTeamEvent(0.4, Game.Score(0, 0), 2, "[player1] pre-sub-3-ref-p1"),
+          Model.OtherTeamEvent(0.4, Game.Score(0, 0), 2, "[player2] pre-sub-4-ref-p2"),
+          Model.OtherOpponentEvent(0.4, Game.Score(0, 0), 2, "[player1] pre-sub-5-ignore-p1"),
+          Model.OtherOpponentEvent(0.4, Game.Score(0, 0), 2, "[player2] pre-sub-6-ignore-p2"),
 
           Model.SubInEvent(0.4, "player1"),
-          Model.OtherTeamEvent(0.4, Game.Score(0, 0), "middle-event"),
+          Model.OtherTeamEvent(0.4, Game.Score(0, 0), 3, "middle-event"),
           Model.SubOutEvent(0.4, "player2"),
 
-          Model.OtherTeamEvent(0.4, Game.Score(0, 0), "post-sub-1-no-ref"),
-          Model.OtherOpponentEvent(0.4, Game.Score(0, 0), "post-sub-2-no-ref"),
-          Model.OtherTeamEvent(0.4, Game.Score(0, 0), "[player1] post-sub-3-ref-p1"),
-          Model.OtherTeamEvent(0.4, Game.Score(0, 0), "[player2] post-sub-4-ref-p2"),
-          Model.OtherOpponentEvent(0.4, Game.Score(0, 0), "[player1] post-sub-5-ignore-p1"),
-          Model.OtherOpponentEvent(0.4, Game.Score(0, 0), "[player2] post-sub-6-ignore-p2")
+          Model.OtherTeamEvent(0.4, Game.Score(0, 0), 3, "post-sub-1-no-ref"),
+          Model.OtherOpponentEvent(0.4, Game.Score(0, 0), 3, "post-sub-2-no-ref"),
+          Model.OtherTeamEvent(0.4, Game.Score(0, 0), 4, "[player1] post-sub-3-ref-p1"),
+          Model.OtherTeamEvent(0.4, Game.Score(0, 0), 4, "[player2] post-sub-4-ref-p2"),
+          Model.OtherOpponentEvent(0.4, Game.Score(0, 0), 4, "[player1] post-sub-5-ignore-p1"),
+          Model.OtherOpponentEvent(0.4, Game.Score(0, 0), 4, "[player2] post-sub-6-ignore-p2")
         )
 
         // (check trivial case )
@@ -169,8 +169,8 @@ object ExtractorUtilsTests extends TestSuite {
           //(note player6 being all upper case for 2017- and lower case for 2018 is
           // important to this test because we latch format on the first name found)
           Model.SubOutEvent(0.1, player1.id.name) ::
-          Model.OtherTeamEvent(0.2, Game.Score(1, 0), "event1a") ::
-          Model.OtherTeamEvent(0.2, Game.Score(2, 0), "event2a") ::
+          Model.OtherTeamEvent(0.2, Game.Score(1, 0), 1, "event1a") ::
+          Model.OtherTeamEvent(0.2, Game.Score(2, 0), 1, "event2a") ::
           // Second event
           Model.SubInEvent(0.4, player1.id.name) ::
           // confirm that all upper case names are returned to normal form:
@@ -178,16 +178,16 @@ object ExtractorUtilsTests extends TestSuite {
           // CHECK: we only care about "code" not "id":
           Model.SubOutEvent(0.4, player2.id.name.toUpperCase + " ii") ::
           Model.SubOutEvent(0.4, player4.id.name) ::
-          Model.OtherOpponentEvent(0.4, Game.Score(1, 1), "event1b") ::
-          Model.OtherOpponentEvent(0.4, Game.Score(1, 2), "event2b") ::
-          Model.OtherTeamEvent(0.4, Game.Score(3, 2), "event3a") ::
-          Model.OtherTeamEvent(0.4, Game.Score(4, 2), "event4a") ::
+          Model.OtherOpponentEvent(0.4, Game.Score(1, 1), 1, "event1b") ::
+          Model.OtherOpponentEvent(0.4, Game.Score(1, 2), 1, "event2b") ::
+          Model.OtherTeamEvent(0.4, Game.Score(3, 2), 2, "event3a") ::
+          Model.OtherTeamEvent(0.4, Game.Score(4, 2), 2, "event4a") ::
           // Half time! (third event)
           Model.GameBreakEvent(20.0) ::
           // (subs happen immediately after break)
           Model.SubOutEvent(20.0, player1.id.name) ::
-          Model.OtherOpponentEvent(20.0, Game.Score(4, 2), "PlayerA Leaves Game") :: //opponents can sub too....
-          Model.OtherOpponentEvent(20.0, Game.Score(4, 2), "PlayerB, substitution in") :: //(new format))
+          Model.OtherOpponentEvent(20.0, Game.Score(4, 2), 2, "PlayerA Leaves Game") :: //opponents can sub too....
+          Model.OtherOpponentEvent(20.0, Game.Score(4, 2), 2, "PlayerB, substitution in") :: //(new format))
           Model.SubInEvent(20.0, player6.id.name) ::
           // Fourth event  - sub-on-sub action
           Model.SubOutEvent(20.4, player2.id.name) ::
@@ -197,12 +197,12 @@ object ExtractorUtilsTests extends TestSuite {
           // Overtime! (first event)
           Model.GameBreakEvent(40.0) ::
           // Sixth event
-          Model.OtherOpponentEvent(40.4, Game.Score(4, 3), "event3b") ::
-          Model.OtherTeamEvent(40.4, Game.Score(5, 3), "event5a") ::
+          Model.OtherOpponentEvent(40.4, Game.Score(4, 3), 3, "event3b") ::
+          Model.OtherTeamEvent(40.4, Game.Score(5, 3), 3, "event5a") ::
           Model.SubInEvent(40.5, player6.id.name) ::
           Model.SubOutEvent(40.5, player1.id.name) ::
-          Model.OtherTeamEvent(40.6, Game.Score(6, 3), "event6a") ::
-          Model.OtherOpponentEvent(40.7, Game.Score(6, 4) , "event4b") ::
+          Model.OtherTeamEvent(40.6, Game.Score(6, 3), 3, "event6a") ::
+          Model.OtherOpponentEvent(40.7, Game.Score(6, 4) , 4, "event4b") ::
           // Fin (Seventh event)
           Model.GameEndEvent(45.0) ::
           Nil

--- a/src/test/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/ExtractorUtilsTests.scala
+++ b/src/test/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/ExtractorUtilsTests.scala
@@ -84,23 +84,23 @@ object ExtractorUtilsTests extends TestSuite {
         //  but want to demonstrate all the branches of this somewhat complex sub function)
 
         val event_list @ (event_list_1 :: event_list_2 :: event_list_rest) = List(
-          Model.OtherTeamEvent(0.4, Game.Score(0, 0), 1, "pre-sub-1-no-ref"),
-          Model.OtherOpponentEvent(0.4, Game.Score(0, 0), 1, "pre-sub-2-no-ref"),
-          Model.OtherTeamEvent(0.4, Game.Score(0, 0), 2, "[player1] pre-sub-3-ref-p1"),
-          Model.OtherTeamEvent(0.4, Game.Score(0, 0), 2, "[player2] pre-sub-4-ref-p2"),
-          Model.OtherOpponentEvent(0.4, Game.Score(0, 0), 2, "[player1] pre-sub-5-ignore-p1"),
-          Model.OtherOpponentEvent(0.4, Game.Score(0, 0), 2, "[player2] pre-sub-6-ignore-p2"),
+          Model.OtherTeamEvent(0.4, Game.Score(0, 0), "pre-sub-1-no-ref"),
+          Model.OtherOpponentEvent(0.4, Game.Score(0, 0), "pre-sub-2-no-ref"),
+          Model.OtherTeamEvent(0.4, Game.Score(0, 0), "[player1] pre-sub-3-ref-p1"),
+          Model.OtherTeamEvent(0.4, Game.Score(0, 0), "[player2] pre-sub-4-ref-p2"),
+          Model.OtherOpponentEvent(0.4, Game.Score(0, 0), "[player1] pre-sub-5-ignore-p1"),
+          Model.OtherOpponentEvent(0.4, Game.Score(0, 0), "[player2] pre-sub-6-ignore-p2"),
 
           Model.SubInEvent(0.4, "player1"),
-          Model.OtherTeamEvent(0.4, Game.Score(0, 0), 3, "middle-event"),
+          Model.OtherTeamEvent(0.4, Game.Score(0, 0), "middle-event"),
           Model.SubOutEvent(0.4, "player2"),
 
-          Model.OtherTeamEvent(0.4, Game.Score(0, 0), 3, "post-sub-1-no-ref"),
-          Model.OtherOpponentEvent(0.4, Game.Score(0, 0), 3, "post-sub-2-no-ref"),
-          Model.OtherTeamEvent(0.4, Game.Score(0, 0), 4, "[player1] post-sub-3-ref-p1"),
-          Model.OtherTeamEvent(0.4, Game.Score(0, 0), 4, "[player2] post-sub-4-ref-p2"),
-          Model.OtherOpponentEvent(0.4, Game.Score(0, 0), 4, "[player1] post-sub-5-ignore-p1"),
-          Model.OtherOpponentEvent(0.4, Game.Score(0, 0), 4, "[player2] post-sub-6-ignore-p2")
+          Model.OtherTeamEvent(0.4, Game.Score(0, 0), "post-sub-1-no-ref"),
+          Model.OtherOpponentEvent(0.4, Game.Score(0, 0), "post-sub-2-no-ref"),
+          Model.OtherTeamEvent(0.4, Game.Score(0, 0), "[player1] post-sub-3-ref-p1"),
+          Model.OtherTeamEvent(0.4, Game.Score(0, 0), "[player2] post-sub-4-ref-p2"),
+          Model.OtherOpponentEvent(0.4, Game.Score(0, 0), "[player1] post-sub-5-ignore-p1"),
+          Model.OtherOpponentEvent(0.4, Game.Score(0, 0), "[player2] post-sub-6-ignore-p2")
         )
 
         // (check trivial case )
@@ -169,8 +169,8 @@ object ExtractorUtilsTests extends TestSuite {
           //(note player6 being all upper case for 2017- and lower case for 2018 is
           // important to this test because we latch format on the first name found)
           Model.SubOutEvent(0.1, player1.id.name) ::
-          Model.OtherTeamEvent(0.2, Game.Score(1, 0), 1, "event1a") ::
-          Model.OtherTeamEvent(0.2, Game.Score(2, 0), 1, "event2a") ::
+          Model.OtherTeamEvent(0.2, Game.Score(1, 0), "event1a") ::
+          Model.OtherTeamEvent(0.2, Game.Score(2, 0), "event2a") ::
           // Second event
           Model.SubInEvent(0.4, player1.id.name) ::
           // confirm that all upper case names are returned to normal form:
@@ -178,16 +178,16 @@ object ExtractorUtilsTests extends TestSuite {
           // CHECK: we only care about "code" not "id":
           Model.SubOutEvent(0.4, player2.id.name.toUpperCase + " ii") ::
           Model.SubOutEvent(0.4, player4.id.name) ::
-          Model.OtherOpponentEvent(0.4, Game.Score(1, 1), 1, "event1b") ::
-          Model.OtherOpponentEvent(0.4, Game.Score(1, 2), 1, "event2b") ::
-          Model.OtherTeamEvent(0.4, Game.Score(3, 2), 2, "event3a") ::
-          Model.OtherTeamEvent(0.4, Game.Score(4, 2), 2, "event4a") ::
+          Model.OtherOpponentEvent(0.4, Game.Score(1, 1), "event1b") ::
+          Model.OtherOpponentEvent(0.4, Game.Score(1, 2), "event2b") ::
+          Model.OtherTeamEvent(0.4, Game.Score(3, 2), "event3a") ::
+          Model.OtherTeamEvent(0.4, Game.Score(4, 2), "event4a") ::
           // Half time! (third event)
           Model.GameBreakEvent(20.0) ::
           // (subs happen immediately after break)
           Model.SubOutEvent(20.0, player1.id.name) ::
-          Model.OtherOpponentEvent(20.0, Game.Score(4, 2), 2, "PlayerA Leaves Game") :: //opponents can sub too....
-          Model.OtherOpponentEvent(20.0, Game.Score(4, 2), 2, "PlayerB, substitution in") :: //(new format))
+          Model.OtherOpponentEvent(20.0, Game.Score(4, 2), "PlayerA Leaves Game") :: //opponents can sub too....
+          Model.OtherOpponentEvent(20.0, Game.Score(4, 2), "PlayerB, substitution in") :: //(new format))
           Model.SubInEvent(20.0, player6.id.name) ::
           // Fourth event  - sub-on-sub action
           Model.SubOutEvent(20.4, player2.id.name) ::
@@ -197,12 +197,12 @@ object ExtractorUtilsTests extends TestSuite {
           // Overtime! (first event)
           Model.GameBreakEvent(40.0) ::
           // Sixth event
-          Model.OtherOpponentEvent(40.4, Game.Score(4, 3), 3, "event3b") ::
-          Model.OtherTeamEvent(40.4, Game.Score(5, 3), 3, "event5a") ::
+          Model.OtherOpponentEvent(40.4, Game.Score(4, 3), "event3b") ::
+          Model.OtherTeamEvent(40.4, Game.Score(5, 3), "event5a") ::
           Model.SubInEvent(40.5, player6.id.name) ::
           Model.SubOutEvent(40.5, player1.id.name) ::
-          Model.OtherTeamEvent(40.6, Game.Score(6, 3), 3, "event6a") ::
-          Model.OtherOpponentEvent(40.7, Game.Score(6, 4) , 4, "event4b") ::
+          Model.OtherTeamEvent(40.6, Game.Score(6, 3), "event6a") ::
+          Model.OtherOpponentEvent(40.7, Game.Score(6, 4) , "event4b") ::
           // Fin (Seventh event)
           Model.GameEndEvent(45.0) ::
           Nil

--- a/src/test/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/LineupUtilsTests.scala
+++ b/src/test/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/LineupUtilsTests.scala
@@ -39,7 +39,7 @@ object LineupUtilsTests extends TestSuite with LineupUtils {
 
         TestUtils.inside(enrich_lineup(test_lineup_1)) {
           case enriched_lineup =>
-            enriched_lineup.team_stats.num_events ==> 1
+            enriched_lineup.team_stats.num_events ==> 0
             enriched_lineup.team_stats.num_possessions ==> 0
             enriched_lineup.team_stats.pts ==> 2
             enriched_lineup.team_stats.plus_minus ==> 1

--- a/src/test/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/LineupUtilsTests.scala
+++ b/src/test/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/LineupUtilsTests.scala
@@ -11,8 +11,8 @@ object LineupUtilsTests extends TestSuite with LineupUtils {
   val tests = Tests {
     "LineupUtils" - {
       "enrich_lineup" - {
-        val test_events_1 = LineupEvent.RawGameEvent(Some("19:58:00,0-0,team1.1"), None, Some(1), None) :: Nil
-        val test_events_2 = LineupEvent.RawGameEvent(None, Some("19:58:00,0-0,opp1.1"), None, Some(1)) :: Nil
+        val test_events_1 = LineupEvent.RawGameEvent(0.0, Some("19:58:00,0-0,team1.1"), None) :: Nil
+        val test_events_2 = LineupEvent.RawGameEvent(0.0, None, Some("19:58:00,0-0,opp1.1")) :: Nil
 
         val base_lineup = LineupEvent(
           date = new DateTime(),

--- a/src/test/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/LineupUtilsTests.scala
+++ b/src/test/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/LineupUtilsTests.scala
@@ -37,10 +37,10 @@ object LineupUtilsTests extends TestSuite with LineupUtils {
         val test_lineup_1 = base_lineup.copy(raw_game_events = test_events_1)
         val test_lineup_2 = base_lineup.copy(raw_game_events = test_events_2)
 
-        TestUtils.inside(enrich_lineup(test_lineup_1, None)) {
-          case (enriched_lineup, None) =>
+        TestUtils.inside(enrich_lineup(test_lineup_1)) {
+          case enriched_lineup =>
             enriched_lineup.team_stats.num_events ==> 1
-            enriched_lineup.team_stats.num_possessions ==> 1
+            enriched_lineup.team_stats.num_possessions ==> 0
             enriched_lineup.team_stats.pts ==> 2
             enriched_lineup.team_stats.plus_minus ==> 1
 
@@ -48,119 +48,6 @@ object LineupUtilsTests extends TestSuite with LineupUtils {
             enriched_lineup.opponent_stats.num_possessions ==> 0
             enriched_lineup.opponent_stats.pts ==> 1
             enriched_lineup.opponent_stats.plus_minus ==> -1
-        }
-        TestUtils.inside(enrich_lineup(test_lineup_1, Some(test_lineup_2))) {
-          case (enriched_lineup, Some(`test_lineup_2`)) =>
-            //(we're just validating that we correctly leave the prev lineup alone)
-        }
-
-        TestUtils.inside(enrich_lineup(test_lineup_1, Some(test_lineup_1))) {
-          case (enriched_lineup, Some(adjusted_lineup)) =>
-            enriched_lineup.team_stats.num_possessions ==> 1
-            enriched_lineup.opponent_stats.num_possessions ==> 0
-
-            // The important bit:
-            adjusted_lineup.team_stats.num_possessions ==> -1
-            adjusted_lineup.opponent_stats.num_possessions ==> 0
-        }
-        TestUtils.inside(enrich_lineup(test_lineup_2, Some(test_lineup_1))) {
-          case (enriched_lineup, Some(`test_lineup_1`)) =>
-          enriched_lineup.team_stats.num_events ==> 0
-          enriched_lineup.team_stats.num_possessions ==> 0
-          enriched_lineup.opponent_stats.num_events ==> 1
-          enriched_lineup.opponent_stats.num_possessions ==> 1
-        }
-        TestUtils.inside(enrich_lineup(test_lineup_2, Some(test_lineup_2))) {
-          case (enriched_lineup, Some(adjusted_lineup)) =>
-            enriched_lineup.team_stats.num_possessions ==> 0
-            enriched_lineup.opponent_stats.num_possessions ==> 1
-
-            // The important bit:
-            adjusted_lineup.team_stats.num_possessions ==> 0
-            adjusted_lineup.opponent_stats.num_possessions ==> -1
-        }
-      }
-      "calculate_possessions" - {
-        val test_events_1 = //(set expected possession -1)
-          LineupEvent.RawGameEvent(Some("19:58:00,0-0,player, jumpball lost"), None, None, None) ::
-          LineupEvent.RawGameEvent(None, Some("19:58:01,0-0,player, jumpball won"), None, None) ::
-          LineupEvent.RawGameEvent(Some("19:58:02,0-0,team1.1"), None, Some(0), None) ::
-          LineupEvent.RawGameEvent(None, Some("19:58:03,0-0,player, substitution out"), Some(0), None) ::
-          LineupEvent.RawGameEvent(Some("19:58:04,0-0,team1.2"), None, Some(0), None) ::
-          LineupEvent.RawGameEvent(None, Some("19:58:05,0-0,opp1.1"), None, Some(0)) ::
-          LineupEvent.RawGameEvent(None, Some("19:58:06,0-0,player, substitution in"), None, Some(0)) ::
-          LineupEvent.RawGameEvent(Some("19:58:07,0-0, team2.1"), None, Some(1), None) ::
-          LineupEvent.RawGameEvent(None, Some("19:58:08,0-0,PLAYER Leaves Game"), Some(1), None) ::
-          LineupEvent.RawGameEvent(None, Some("19:58:09,0-0,PLAYER Enters Game"), Some(1), None) ::
-          LineupEvent.RawGameEvent(None, Some("19:58:10,0-0,opp2.1"), None, Some(1)) ::
-          LineupEvent.RawGameEvent(Some("19:58:11,0-0,team3.1"), None, Some(2), None) ::
-          Nil
-        TestUtils.inside(calculate_possessions(test_events_1, None)) {
-          case (3, 2, events, false) =>
-            events ==> test_events_1.map(e => e.copy(
-              team_possession = e.team_possession.map(_ + 1),
-              opponent_possession = e.opponent_possession.map(_ + 1),
-            ))
-        }
-
-        val test_events_2 = LineupEvent.RawGameEvent(None, Some("19:58:00,0-0,opp1.1")) :: Nil
-        TestUtils.inside(calculate_possessions(test_events_2, None)) {
-          case (0, 1, events, false) =>
-            events ==> events.map(_.copy(opponent_possession = Some(1)))
-        }
-
-        val jumpball_event = Some("19:58:01,0-0,player, jumpball lost")
-        val timeout_event = Some("19:58:02,0-0,player, team, timeout short")
-        val block_event = Some("19:58:03,0-0,player Blocked Shot")
-        val steal_event = Some("19:58:04,0-0,player Steal")
-        val personal_foul_event = Some("19:58:05,0-0,player, foul personal; info")
-        val technical_foul_event = Some("19:58:06,0-0,player, foul technical classa; info")
-        val foul_info_event = Some("19:58:07,0-0,player, foulon")
-        val test_events_3 = //(set expected possession -1)
-          LineupEvent.RawGameEvent(Some("19:58:00,0-0,player, team1.1"), None, Some(0), None) ::
-          LineupEvent.RawGameEvent(None, jumpball_event, Some(0), None) ::
-          LineupEvent.RawGameEvent(None, timeout_event, Some(0), None) ::
-          LineupEvent.RawGameEvent(None, block_event, Some(0), None) ::
-          LineupEvent.RawGameEvent(None, steal_event, Some(0), None) ::
-          LineupEvent.RawGameEvent(None, personal_foul_event, Some(0), None) ::
-          LineupEvent.RawGameEvent(None, technical_foul_event, Some(0), None) ::
-          LineupEvent.RawGameEvent(None, foul_info_event, Some(0), None) ::
-          LineupEvent.RawGameEvent(Some("19:58:10,0-0,player, team1.2"), None, Some(0), None) ::
-          LineupEvent.RawGameEvent(None, Some("19:58:20,0-0,player, opp1.1"), None, Some(0)) ::
-          LineupEvent.RawGameEvent(jumpball_event, None, None, Some(0)) ::
-          LineupEvent.RawGameEvent(timeout_event, None, None, Some(0)) ::
-          LineupEvent.RawGameEvent(block_event, None, None, Some(0)) ::
-          LineupEvent.RawGameEvent(steal_event, None, None, Some(0)) ::
-          LineupEvent.RawGameEvent(personal_foul_event, None, None, Some(0)) ::
-          LineupEvent.RawGameEvent(technical_foul_event, None, None, Some(0)) ::
-          LineupEvent.RawGameEvent(foul_info_event, None, None, Some(0)) ::
-          LineupEvent.RawGameEvent(None, Some("19:58:30,0-0,player, opp1.2"), None, Some(0)) ::
-          Nil
-        TestUtils.inside(calculate_possessions(test_events_3, None)) {
-          case (1, 1, events, false) =>
-            events ==> test_events_3.map(e => e.copy(
-              team_possession = e.team_possession.map(_ + 1),
-              opponent_possession = e.opponent_possession.map(_ + 1),
-            ))
-        }
-
-        // Check adjustments to previous lineup:
-        val misc_team_event =
-          LineupEvent.RawGameEvent(Some("19:58:00,0-0,player, team1.2"), None, Some(0), None)
-        val misc_opponent_event =
-          LineupEvent.RawGameEvent(Some("19:58:00,0-0,player, team1.2"), None, None, Some(0))
-
-        TestUtils.inside(calculate_possessions(test_events_1, Some(misc_team_event))) {
-          case (_, _, _, true) =>
-        }
-        TestUtils.inside(calculate_possessions(test_events_1, Some(misc_opponent_event))) {
-          case (_, _, _, false) =>
-        }
-        TestUtils.inside(calculate_possessions(test_events_2, Some(misc_team_event))) {
-          case (_, _, _, false) =>
-        }
-        TestUtils.inside(calculate_possessions(test_events_2, Some(misc_opponent_event))) {
-          case (_, _, _, true) =>
         }
       }
       "fix_possible_score_swap_bug" - {

--- a/src/test/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/PlayByPlayParserTests.scala
+++ b/src/test/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/PlayByPlayParserTests.scala
@@ -141,20 +141,20 @@ object PlayByPlayParserTests extends TestSuite with PlayByPlayParser {
       "enrich_and_reverse_game_events" - {
         val score = Game.Score(1, 1)
         val test_list =
-          Model.OtherTeamEvent(2.0, score, 0, "test1") ::
-          Model.OtherTeamEvent(3.0, score, 0, "test2a") ::
-          Model.OtherTeamEvent(2.0, score, 0, "test2b") ::
-          Model.OtherTeamEvent(2.5, score, 0, "test3") ::
+          Model.OtherTeamEvent(2.0, score, "test1") ::
+          Model.OtherTeamEvent(3.0, score, "test2a") ::
+          Model.OtherTeamEvent(2.0, score, "test2b") ::
+          Model.OtherTeamEvent(2.5, score, "test3") ::
           Nil
         TestUtils.inside(enrich_and_reverse_game_events(test_list)) {
           case List(
             Model.GameEndEvent(end_t),
-            Model.OtherTeamEvent(game_t_3, _, _, "test3"),
+            Model.OtherTeamEvent(game_t_3, _, "test3"),
             Model.GameBreakEvent(mid_t_2),
-            Model.OtherTeamEvent(game_t_2b, _, _, "test2b"),
-            Model.OtherTeamEvent(game_t_2a, _, _, "test2a"),
+            Model.OtherTeamEvent(game_t_2b, _, "test2b"),
+            Model.OtherTeamEvent(game_t_2a, _, "test2a"),
             Model.GameBreakEvent(mid_t_1),
-            Model.OtherTeamEvent(game_t_1, _, _, "test1")
+            Model.OtherTeamEvent(game_t_1, _, "test1")
           ) =>
           "%.1f".format(game_t_1) ==> "18.0"
           "%.1f".format(mid_t_1) ==> "20.0"
@@ -281,13 +281,13 @@ object PlayByPlayParserTests extends TestSuite with PlayByPlayParser {
         }
         TestUtils.with_doc(sample_team_event) { doc =>
           TestUtils.inside(parse_game_event(doc.body, target_team_first = true)) {
-            case Right(List(Model.OtherTeamEvent(t, Game.Score(45, 26), 0, "15:00,45-26,event text"))) =>
+            case Right(List(Model.OtherTeamEvent(t, Game.Score(45, 26), "15:00,45-26,event text"))) =>
               "%.1f".format(t) ==> "15.0"
           }
         }
         TestUtils.with_doc(sample_oppo_event) { doc =>
           TestUtils.inside(parse_game_event(doc.body, target_team_first = true)) {
-            case Right(List(Model.OtherOpponentEvent(t, Game.Score(45, 26), 0, "15:00,45-26,event text"))) =>
+            case Right(List(Model.OtherOpponentEvent(t, Game.Score(45, 26), "15:00,45-26,event text"))) =>
               "%.1f".format(t) ==> "15.0"
           }
         }
@@ -305,7 +305,7 @@ object PlayByPlayParserTests extends TestSuite with PlayByPlayParser {
         }
         TestUtils.with_doc(sample_oppo_sub_in) { doc =>
           TestUtils.inside(parse_game_event(doc.body, target_team_first = true)) {
-            case Right(List(Model.OtherOpponentEvent(t, Game.Score(45, 26), 0, "15:00,45-26,S8RNAME,F8RSTNAME TEAMB Enters Game"))) =>
+            case Right(List(Model.OtherOpponentEvent(t, Game.Score(45, 26), "15:00,45-26,S8RNAME,F8RSTNAME TEAMB Enters Game"))) =>
               "%.1f".format(t) ==> "15.0"
           }
         }
@@ -321,13 +321,13 @@ object PlayByPlayParserTests extends TestSuite with PlayByPlayParser {
               "%.1f".format(t) ==> "15.0"
           }
           TestUtils.inside(parse_game_event(doc.body, target_team_first = false)) {
-            case Right(List(Model.OtherOpponentEvent(t, Game.Score(26, 45), 0, "15:00,45-26,F5rstname TeamA S5rname, substitution out"))) =>
+            case Right(List(Model.OtherOpponentEvent(t, Game.Score(26, 45), "15:00,45-26,F5rstname TeamA S5rname, substitution out"))) =>
               "%.1f".format(t) ==> "15.0"
           }
         }
         TestUtils.with_doc(sample_oppo_sub_out) { doc =>
           TestUtils.inside(parse_game_event(doc.body, target_team_first = true)) {
-            case Right(List(Model.OtherOpponentEvent(t, Game.Score(45, 26), 0, "15:00,45-26,S8RNAME,F8RSTNAME TEAMB Leaves Game"))) =>
+            case Right(List(Model.OtherOpponentEvent(t, Game.Score(45, 26), "15:00,45-26,S8RNAME,F8RSTNAME TEAMB Leaves Game"))) =>
               "%.1f".format(t) ==> "15.0"
           }
           TestUtils.inside(parse_game_event(doc.body, target_team_first = false)) {

--- a/src/test/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/PlayByPlayParserTests.scala
+++ b/src/test/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/PlayByPlayParserTests.scala
@@ -148,12 +148,12 @@ object PlayByPlayParserTests extends TestSuite with PlayByPlayParser {
           Nil
         TestUtils.inside(enrich_and_reverse_game_events(test_list)) {
           case List(
-            Model.GameEndEvent(end_t),
+            Model.GameEndEvent(end_t, _),
             Model.OtherTeamEvent(game_t_3, _, "test3"),
-            Model.GameBreakEvent(mid_t_2),
+            Model.GameBreakEvent(mid_t_2, _),
             Model.OtherTeamEvent(game_t_2b, _, "test2b"),
             Model.OtherTeamEvent(game_t_2a, _, "test2a"),
-            Model.GameBreakEvent(mid_t_1),
+            Model.GameBreakEvent(mid_t_1, _),
             Model.OtherTeamEvent(game_t_1, _, "test1")
           ) =>
           "%.1f".format(game_t_1) ==> "18.0"
@@ -293,13 +293,13 @@ object PlayByPlayParserTests extends TestSuite with PlayByPlayParser {
         }
         TestUtils.with_doc(sample_team_sub_in) { doc =>
           TestUtils.inside(parse_game_event(doc.body, target_team_first = true)) {
-            case Right(List(Model.SubInEvent(t, "S8RNAME,F8RSTNAME TEAMA"))) =>
+            case Right(List(Model.SubInEvent(t, _, "S8RNAME,F8RSTNAME TEAMA"))) =>
               "%.1f".format(t) ==> "15.0"
           }
         }
         TestUtils.with_doc(sample_team_sub_in_new_format) { doc =>
           TestUtils.inside(parse_game_event(doc.body, target_team_first = true)) {
-            case Right(List(Model.SubInEvent(t, "F5rstname TeamA S5rname"))) =>
+            case Right(List(Model.SubInEvent(t, _, "F5rstname TeamA S5rname"))) =>
               "%.1f".format(t) ==> "15.0"
           }
         }
@@ -311,13 +311,13 @@ object PlayByPlayParserTests extends TestSuite with PlayByPlayParser {
         }
         TestUtils.with_doc(sample_team_sub_out) { doc =>
           TestUtils.inside(parse_game_event(doc.body, target_team_first = true)) {
-            case Right(List(Model.SubOutEvent(t, "S8RNAME,F8RSTNAME TEAMA"))) =>
+            case Right(List(Model.SubOutEvent(t, _, "S8RNAME,F8RSTNAME TEAMA"))) =>
               "%.1f".format(t) ==> "15.0"
           }
         }
         TestUtils.with_doc(sample_team_sub_out_new_format) { doc =>
           TestUtils.inside(parse_game_event(doc.body, target_team_first = true)) {
-            case Right(List(Model.SubOutEvent(t, "F5rstname TeamA S5rname"))) =>
+            case Right(List(Model.SubOutEvent(t, _, "F5rstname TeamA S5rname"))) =>
               "%.1f".format(t) ==> "15.0"
           }
           TestUtils.inside(parse_game_event(doc.body, target_team_first = false)) {
@@ -331,7 +331,7 @@ object PlayByPlayParserTests extends TestSuite with PlayByPlayParser {
               "%.1f".format(t) ==> "15.0"
           }
           TestUtils.inside(parse_game_event(doc.body, target_team_first = false)) {
-            case Right(List(Model.SubOutEvent(t, "S8RNAME,F8RSTNAME TEAMB"))) =>
+            case Right(List(Model.SubOutEvent(t, _, "S8RNAME,F8RSTNAME TEAMB"))) =>
               "%.1f".format(t) ==> "15.0"
           }
         }

--- a/src/test/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/PlayByPlayParserTests.scala
+++ b/src/test/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/PlayByPlayParserTests.scala
@@ -45,7 +45,7 @@ object PlayByPlayParserTests extends TestSuite with PlayByPlayParser {
           "S4rname, F4rstname TeamA" ::
           "S5rname, F5rstname TeamA" ::
           "S6rname, F6rstname TeamA" ::
-          "S7rname, F7rstname TeamA" :: 
+          "S7rname, F7rstname TeamA" ::
           "S8rname, F8rstname TeamA" ::
           "S9rname, F9rstname TeamA" ::
           Nil
@@ -141,20 +141,20 @@ object PlayByPlayParserTests extends TestSuite with PlayByPlayParser {
       "enrich_and_reverse_game_events" - {
         val score = Game.Score(1, 1)
         val test_list =
-          Model.OtherTeamEvent(2.0, score, "test1") ::
-          Model.OtherTeamEvent(3.0, score, "test2a") ::
-          Model.OtherTeamEvent(2.0, score, "test2b") ::
-          Model.OtherTeamEvent(2.5, score, "test3") ::
+          Model.OtherTeamEvent(2.0, score, 0, "test1") ::
+          Model.OtherTeamEvent(3.0, score, 0, "test2a") ::
+          Model.OtherTeamEvent(2.0, score, 0, "test2b") ::
+          Model.OtherTeamEvent(2.5, score, 0, "test3") ::
           Nil
         TestUtils.inside(enrich_and_reverse_game_events(test_list)) {
           case List(
             Model.GameEndEvent(end_t),
-            Model.OtherTeamEvent(game_t_3, _, "test3"),
+            Model.OtherTeamEvent(game_t_3, _, _, "test3"),
             Model.GameBreakEvent(mid_t_2),
-            Model.OtherTeamEvent(game_t_2b, _, "test2b"),
-            Model.OtherTeamEvent(game_t_2a, _, "test2a"),
+            Model.OtherTeamEvent(game_t_2b, _, _, "test2b"),
+            Model.OtherTeamEvent(game_t_2a, _, _, "test2a"),
             Model.GameBreakEvent(mid_t_1),
-            Model.OtherTeamEvent(game_t_1, _, "test1")
+            Model.OtherTeamEvent(game_t_1, _, _, "test1")
           ) =>
           "%.1f".format(game_t_1) ==> "18.0"
           "%.1f".format(mid_t_1) ==> "20.0"
@@ -281,13 +281,13 @@ object PlayByPlayParserTests extends TestSuite with PlayByPlayParser {
         }
         TestUtils.with_doc(sample_team_event) { doc =>
           TestUtils.inside(parse_game_event(doc.body, target_team_first = true)) {
-            case Right(List(Model.OtherTeamEvent(t, Game.Score(45, 26), "15:00,45-26,event text"))) =>
+            case Right(List(Model.OtherTeamEvent(t, Game.Score(45, 26), 0, "15:00,45-26,event text"))) =>
               "%.1f".format(t) ==> "15.0"
           }
         }
         TestUtils.with_doc(sample_oppo_event) { doc =>
           TestUtils.inside(parse_game_event(doc.body, target_team_first = true)) {
-            case Right(List(Model.OtherOpponentEvent(t, Game.Score(45, 26), "15:00,45-26,event text"))) =>
+            case Right(List(Model.OtherOpponentEvent(t, Game.Score(45, 26), 0, "15:00,45-26,event text"))) =>
               "%.1f".format(t) ==> "15.0"
           }
         }
@@ -305,7 +305,7 @@ object PlayByPlayParserTests extends TestSuite with PlayByPlayParser {
         }
         TestUtils.with_doc(sample_oppo_sub_in) { doc =>
           TestUtils.inside(parse_game_event(doc.body, target_team_first = true)) {
-            case Right(List(Model.OtherOpponentEvent(t, Game.Score(45, 26), "15:00,45-26,S8RNAME,F8RSTNAME TEAMB Enters Game"))) =>
+            case Right(List(Model.OtherOpponentEvent(t, Game.Score(45, 26), 0, "15:00,45-26,S8RNAME,F8RSTNAME TEAMB Enters Game"))) =>
               "%.1f".format(t) ==> "15.0"
           }
         }
@@ -321,13 +321,13 @@ object PlayByPlayParserTests extends TestSuite with PlayByPlayParser {
               "%.1f".format(t) ==> "15.0"
           }
           TestUtils.inside(parse_game_event(doc.body, target_team_first = false)) {
-            case Right(List(Model.OtherOpponentEvent(t, Game.Score(26, 45), "15:00,45-26,F5rstname TeamA S5rname, substitution out"))) =>
+            case Right(List(Model.OtherOpponentEvent(t, Game.Score(26, 45), 0, "15:00,45-26,F5rstname TeamA S5rname, substitution out"))) =>
               "%.1f".format(t) ==> "15.0"
           }
         }
         TestUtils.with_doc(sample_oppo_sub_out) { doc =>
           TestUtils.inside(parse_game_event(doc.body, target_team_first = true)) {
-            case Right(List(Model.OtherOpponentEvent(t, Game.Score(45, 26), "15:00,45-26,S8RNAME,F8RSTNAME TEAMB Leaves Game"))) =>
+            case Right(List(Model.OtherOpponentEvent(t, Game.Score(45, 26), 0, "15:00,45-26,S8RNAME,F8RSTNAME TEAMB Leaves Game"))) =>
               "%.1f".format(t) ==> "15.0"
           }
           TestUtils.inside(parse_game_event(doc.body, target_team_first = false)) {

--- a/src/test/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/PossessionUtilsTests.scala
+++ b/src/test/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/PossessionUtilsTests.scala
@@ -42,11 +42,6 @@ object PossessionUtilsTests extends TestSuite with PossessionUtils {
         val orb_opponent = Model.OtherOpponentEvent(0.0, gs, 0, "10:00,51-60,Darryl Morsell, rebound offensive")
         val drb_opponent = Model.OtherOpponentEvent(0.0, gs, 0, "10:00,51-60,Darryl Morsell, rebound defensive")
         val tech_opponent = Model.OtherOpponentEvent(0.0, gs, 0, "06:43:00,55-79,Bruno Fernando, foul technical classa;2freethrow")
-
-        val missed_possession_opponent = Model.OtherOpponentEvent(1.0, gs, 0, s"10:00,51-60, $error_event_string")
-          //(linked to drb_opponent)
-
-        val unknown_team = Model.OtherTeamEvent(0.0, gs, 0, "UNKNOWN_EVENT")
       }
 
       "concurrent_event_handler" - {
@@ -54,7 +49,6 @@ object PossessionUtilsTests extends TestSuite with PossessionUtils {
 
         val test_events @ (
           ev1 :: ev2 :: ev3 :: ev4 :: ev_gb :: ev5 :: ev6 :: ev7
-//TODO:
           :: Nil
         ) =
           // Test minutes based clumping
@@ -67,7 +61,6 @@ object PossessionUtilsTests extends TestSuite with PossessionUtils {
           Model.OtherOpponentEvent(0.9, Game.Score(0, 0), 1, "ev-6") ::
           Model.OtherTeamEvent(1.0, Game.Score(0, 0), 1, "ev-7") ::
           // Test possession directing based clumping
-//TODO:
           Nil
         val test_events_in = test_events.map(ev => ConcurrentClump(ev :: Nil))
 
@@ -92,220 +85,9 @@ object PossessionUtilsTests extends TestSuite with PossessionUtils {
         }
       }
 
-      "first_possession_status" - {
-        val test_event_pairs =
-          (Events.jump_won_team -> Some(Direction.Team)) ::
-          (Events.jump_won_opponent -> Some(Direction.Opponent)) ::
-          (Events.turnover_team -> Some(Direction.Team)) ::
-          (Events.steal_team -> Some(Direction.Team)) :: //Ignored so uses next event
-          (Events.made_team -> Some(Direction.Team)) ::
-          (Events.missed_ft_team -> Some(Direction.Team)) ::
-          (Events.missed_opponent -> Some(Direction.Opponent)) ::
-          (Events.made_ft_opponent -> Some(Direction.Opponent)) ::
-          (Events.unknown_team -> None) ::
-          Nil
-
-        TestUtils.inside(
-          test_event_pairs.zipWithIndex.map(_._2).map { test_index =>
-            first_possession_status(test_event_pairs.drop(test_index).map(_._1))
-          }
-        ) {
-          case l =>
-            val expected = test_event_pairs.map(_._2)
-            if (l != expected) {
-              print_useful_list_diff(l, expected)
-            }
-            l ==> expected
-        }
-      }
-
-      "clump_possession_status" - {
-
-        val test_event_pairs =
-          (Events.drb_opponent.copy(poss = 1) -> PossessionArrowSwitch) :: //(is ignored)
-          (Events.game_break -> PossessionArrowSwitch) ::
-          (Events.drb_opponent -> PossessionEnd) ::
-          (Events.turnover_team -> PossessionEnd) ::
-          (Events.tech_opponent -> PossessionContinues) ::
-          (Events.made_team -> PossessionContinues) :: //(cos of the missed and one next)
-          (Events.missed_ft_team -> PossessionContinues) ::
-          (Events.made_team -> PossessionEnd) ::
-          (Events.made_ft_team -> PossessionEnd) :: //(no missed FTs follow)
-          (Events.made_team -> PossessionEnd) :: //(no FTs after)
-          (Events.unknown_team -> PossessionContinues) :: //(no FTs after)
-          Nil
-
-        val turnover_events =
-          (List(Events.turnover_team) -> PossessionEnd) ::
-          (List(Events.foul_team) -> PossessionEnd) ::
-          (List(Events.foul_team, Events.foul_opponent) -> PossessionContinues) :: //offsetting fouls)
-          Nil
-
-        val missed_ft_events =
-          (List(
-              Events.missed_ft_team.copy(score = Game.Score(10, 0), poss = 1), //(ignored)
-              Events.made_ft_team.copy(score = Game.Score(1, 0)),
-              Events.missed_ft_team.copy(score = Game.Score(0, 0)),
-            ) -> PossessionEnd
-          ) ::
-          (List(
-              Events.made_ft_team.copy(score = Game.Score(0, 0)),
-              Events.missed_ft_team.copy(score = Game.Score(1, 0)),
-            ) -> PossessionContinues
-          ) ::
-          Nil
-
-        val events_that_error_team =
-          (List(Events.steal_team) -> PossessionContinues) :: //(steals and blocks are ignored)
-          (List(Events.missed_opponent) -> PossessionError) ::
-          Nil
-
-        val events_that_error_oppo = //(check DRBs prevent errors occuring)
-          (List(Events.drb_team, Events.made_team) -> PossessionEnd) ::
-          (List(Events.made_team) -> PossessionError) ::
-          (List(Events.turnover_team) -> PossessionError) ::
-          Nil
-
-        val team_state = PossState.init.copy(direction = Direction.Team)
-        val oppo_state = PossState.init.copy(direction = Direction.Opponent)
-
-        sealed trait TestCase
-        case class TestCase1[T](s: PossState, l: List[(Model.PlayByPlayEvent, T)]) extends TestCase
-        case class TestCase2[T](s: PossState, l: List[(List[Model.PlayByPlayEvent], T)]) extends TestCase
-
-        List(
-          TestCase1(team_state, test_event_pairs),
-          TestCase2(team_state, turnover_events),
-          TestCase2(team_state, missed_ft_events),
-          TestCase2(team_state, events_that_error_team),
-          TestCase2(oppo_state, events_that_error_oppo)
-        ).foreach {
-          case TestCase1(s, l) =>
-            TestUtils.inside(
-              l.zipWithIndex.map(_._2).map { test_index =>
-                clump_possession_status(s, l.drop(test_index).map(_._1))
-              }
-            ) {
-              case res =>
-                val expected = l.map(_._2)
-                if (res != expected) {
-                  print_useful_list_diff(res, expected)
-                }
-                res ==> expected
-            }
-            case TestCase2(s, ll) => ll.foreach { case (l, expected) =>
-              TestUtils.inside(clump_possession_status(s, l)) {
-                case res =>
-                  if (res != expected) {
-                    println("+++++++++++++++++++")
-                    println(s"[$l] vs [$res]")
-                    println("-------------------")
-                  }
-                  res ==> expected
-              }
-            }
-        }
-      }
 
       "calculate_possessions" - {
 
-        // Test Cases 1.*: Check that correctly calculates first possession
-        // Test Cases 2.*: Check that rebounds are handled correctly (including compound clumps with DRBs)
-        // Test Cases 3.*: Check that possession change is handled correctly across a game break
-        // Test Cases 4.*: check that missed free throws are handled correctly
-        // Test Cases 5.*: Check that after a possession error everything stops
-        // Test Cases 6.*: Descriptive defensive events can occur _after_ the action event
-
-        val game_1_events = //Test cases 1-3
-          // Jump ball, ignored (1.*)
-          Events.jump_won_team.copy(min = 19.58, poss = -1) ::
-          Events.jump_lost_opponent.copy(min = 19.58, poss = -1) ::
-          // 1T possession - team wins jump (possession arrow to opponent) and scores (1.*)
-          Events.made_team.copy(min = 19.0, poss = -1) ::
-          // 1O possession - DRBs and ORBs (1.*)
-          Events.missed_opponent.copy(min = 18.0, poss = -1) ::
-          Events.orb_opponent.copy(min = 17.0, poss = -1) ::
-          Events.missed_opponent.copy(min = 16.0, poss = -1) ::
-          Events.drb_team.copy(min = 16.0, poss = -1) :: //(DRB belongs to end of offensive possession)
-          // 2T possession (note compound clump)
-          Events.made_team.copy(min = 14.0, poss = -2) ::
-          // 2O possession
-          Events.made_opponent.copy(min = 13.0, poss = -2) ::
-          // Game break (3.*)
-          Events.game_break.copy(min = 10.0) ::
-          // 3O possession
-          Events.made_opponent.copy(min = 20.0, poss = -3) ::
-          // 3T possession - Turnover (3.*, 6.*)
-          Events.turnover_team.copy(min = 19.0, poss = -3) ::
-          Events.steal_opponent.copy(min = 18.0, poss = -3) ::
-          // Game end (check is ignored)
-          Events.game_break.copy(min = 0.0) ::
-          Nil
-
-        val gs1 = Game.Score(0, 1)
-        val gs2 = Game.Score(1, 0)
-
-        val game_2_events = //Test cases 1-5
-          // 1O possession - fouled and made and one (1,*, 2.*, 4.*)
-          Events.made_opponent.copy(min = 19.0, poss = -1) ::
-          Events.made_ft_opponent.copy(min = 19.0, poss = -1) ::
-          // 1T possession - fouled and both free throws made (2.*, 4.*)
-          Events.made_ft_team.copy(min = 18.0, poss = -1) ::
-          Events.made_ft_team.copy(min = 18.0, poss = -1) ::
-          // 2O missed shot (3.*)
-          Events.missed_opponent.copy(min = 17.0, poss = -2) ::
-          Events.drb_team.copy(min = 16.0, poss = -2) ::
-          // Game break (3.*)
-          Events.game_break.copy(min = 15.0) ::
-          // 2T possession - fouled, missed a free throw, ends up it was the first so possession switches (2.*, 4.*)
-          Events.made_ft_team.copy(min = 14.0, score = gs1, poss = -2) ::
-          Events.missed_ft_team.copy(min = 14.0, poss = -2) ::
-          // 3O possession - missed both free throws, ORB so possession continues (2.*, 4.*)
-          Events.missed_ft_opponent.copy(min = 13.0, poss = -3) ::
-          Events.missed_ft_opponent.copy(min = 13.0, poss = -3) ::
-          Events.orb_opponent.copy(min = 12.0, poss = -3) ::
-          // 3O possession continues - missed a free throw, this time it was the 2nd, ORB so possession continues (2.*, 4.*)
-          Events.missed_ft_opponent.copy(min = 11.0, score = gs2, poss = -3) ::
-          Events.made_ft_opponent.copy(min = 11.0, poss = -3) ::
-          Events.orb_opponent.copy(min = 10.0, poss = -3) ::
-          // 3O possession continues - missed a free throw, this time it was the 2nd, DRB so possession switches (2.*, 4.*)
-          Events.missed_ft_opponent.copy(min = 9.0, score = gs2, poss = -3) ::
-          Events.made_ft_opponent.copy(min = 9.0, poss = -3) ::
-          Events.drb_team.copy(min = 8.0, poss = -3) ::
-          // 3T possesion - fouled and missed FT, ORB (2.*, 4.*)
-          Events.made_team.copy(min = 7.0, poss = -3) ::
-          Events.missed_ft_team.copy(min = 7.0, poss = -3) ::
-          Events.orb_team.copy(min = 6.0, poss = -3) ::
-          // 3T possesion - fouled and missed FT, DRB (2.*, 4.*)
-          Events.made_team.copy(min = 5.0, poss = -3) ::
-          Events.missed_ft_team.copy(min = 5.0, poss = -3) ::
-          Events.drb_opponent.copy(min = 4.0, poss = -3) ::
-          // Handle missed possesion (5.x)
-          Events.missed_possession_opponent.copy(min = 3.0, poss = -4) ::
-          Events.made_team.copy(min = 3.0, poss = -4) ::
-          Events.made_opponent.copy(min = 1.0, poss = -5) :: //(5.x check compound clumps)
-          Events.made_team.copy(min = 1.0, poss = -5) ::
-          Nil
-
-        List(
-          game_1_events, game_2_events
-        ).foreach { test_case_events =>
-          val filtered_events = test_case_events.filter {
-            case ev: Model.MiscGameEvent if ev.event_string.contains(error_event_string) => false
-            case _ => true
-          }
-          TestUtils.inside(calculate_possessions(filtered_events)) {
-            case res =>
-              val expected = test_case_events.map {
-                case ev: Model.MiscGameEvent => ev.with_poss(-ev.poss)
-                case ev => ev
-              }
-              if (res != expected) {
-                print_useful_list_diff(res, expected)
-              }
-              res ==> expected
-          }
-        }
       }
     }
   }

--- a/src/test/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/PossessionUtilsTests.scala
+++ b/src/test/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/PossessionUtilsTests.scala
@@ -54,20 +54,22 @@ object PossessionUtilsTests extends TestSuite with PossessionUtils {
       /** A handy compilation of events */
       object Events {
         val game_break = Model.GameBreakEvent(0.9)
+        val jump_won_team = Model.OtherTeamEvent(0.0, gs, 0, "19:58:00,0-0,Bruno Fernando, jumpball won")
+        val jump_lost_opponent = Model.OtherOpponentEvent(0.0, gs, 0, "19:58:00,0-0,Kavell Bigby-Williams, jumpball lost")
 
         val turnover_team = Model.OtherTeamEvent(0.0, gs, 0, "08:44:00,20-23,Bruno Fernando, turnover badpass")
-        val steal_team = Model.OtherTeamEvent(0.0, gs, 1, "05:10,55-68,MASON III,FRANK Steal")
-        val made_team = Model.OtherTeamEvent(0.0, gs, 1, "10:00,51-60,SMITH,JALEN made Three Point Jumper")
-        val made_ft_team = Model.OtherTeamEvent(0.0, gs, 1, "05:10,55-68,Kevin Anderson, freethrow 2of2 made")
-        val missed_ft_team = Model.OtherTeamEvent(0.0, gs, 1, "10:00,51-60,DREAD,MYLES missed Free Throw")
+        val steal_team = Model.OtherTeamEvent(0.0, gs, 0, "05:10,55-68,MASON III,FRANK Steal")
+        val made_team = Model.OtherTeamEvent(0.0, gs, 0, "10:00,51-60,SMITH,JALEN made Three Point Jumper")
+        val made_ft_team = Model.OtherTeamEvent(0.0, gs, 0, "05:10,55-68,Kevin Anderson, freethrow 2of2 made")
+        val missed_ft_team = Model.OtherTeamEvent(0.0, gs, 0, "10:00,51-60,DREAD,MYLES missed Free Throw")
         val orb_team = Model.OtherTeamEvent(0.0, gs, 0, "10:00,51-60,Darryl Morsell, rebound offensive")
         val drb_team = Model.OtherTeamEvent(0.0, gs, 0, "10:00,51-60,Darryl Morsell, rebound defensive")
 
-        val made_opponent = Model.OtherOpponentEvent(0.0, gs, 1, "10:00,51-60,SMITH,JALEN made Three Point Jumper")
+        val made_opponent = Model.OtherOpponentEvent(0.0, gs, 0, "10:00,51-60,SMITH,JALEN made Three Point Jumper")
         val missed_opponent = Model.OtherOpponentEvent(0.0, gs, 0, "02:28:00,27-38,Eric Ayala, 3pt jumpshot 2ndchance missed")
         val foul_opponent = Model.OtherOpponentEvent(0.0, gs, 0, "10:00,51-60,MYKHAILIUK,SVI Commits Foul")
-        val made_ft_opponent = Model.OtherOpponentEvent(0.0, gs, 1, "05:10,55-68,Kevin Anderson, freethrow 2of2 made")
-        val missed_ft_opponent = Model.OtherOpponentEvent(0.0, gs, 1, "10:00,51-60,DREAD,MYLES missed Free Throw")
+        val made_ft_opponent = Model.OtherOpponentEvent(0.0, gs, 0, "05:10,55-68,Kevin Anderson, freethrow 2of2 made")
+        val missed_ft_opponent = Model.OtherOpponentEvent(0.0, gs, 0, "10:00,51-60,DREAD,MYLES missed Free Throw")
 
         val orb_opponent = Model.OtherOpponentEvent(0.0, gs, 0, "10:00,51-60,Darryl Morsell, rebound offensive")
         val drb_opponent = Model.OtherOpponentEvent(0.0, gs, 0, "10:00,51-60,Darryl Morsell, rebound defensive")
@@ -91,53 +93,58 @@ object PossessionUtilsTests extends TestSuite with PossessionUtils {
           }
         ) {
           case l =>
-            l ==> test_event_pairs.map(_._2)
+            val expected = test_event_pairs.map(_._2)
+            if (l != expected) {
+              print_useful_list_diff(l, expected)
+            }
+            l ==> expected
         }
       }
 
       "clump_possession_status" - {
 
         val test_event_pairs =
+          (Events.drb_opponent.copy(poss = 1) -> PossessionArrowSwitch) :: //(is ignored)
           (Events.game_break -> PossessionArrowSwitch) ::
-          (Events.drb_opponent -> PossessionEnd(last_clump = true)) ::
+          (Events.drb_opponent -> PossessionEnd(compound_clump = true)) ::
           (Events.turnover_team -> PossessionEnd()) ::
           (Events.tech_opponent -> PossessionContinues) ::
           (Events.made_team -> PossessionContinues) :: //(cos of the missed and one next)
-          (Events.missed_ft_team -> PossessionContinues) :: //(_not_ unclear because of shot makes ahead)
+          (Events.missed_ft_team -> PossessionContinues) ::
           (Events.made_team -> PossessionEnd()) ::
           (Events.made_ft_team -> PossessionEnd()) :: //(no missed FTs follow)
           (Events.made_team -> PossessionEnd()) :: //(no FTs after)
           (Events.unknown_team -> PossessionContinues) :: //(no FTs after)
           Nil
 
-        val opponent_ft_pairs =
-          (Events.made_ft_opponent -> PossessionUnclear) ::
-          (Events.missed_ft_opponent -> PossessionContinues) ::
+        val missed_ft_events =
+          (List(
+              Events.missed_ft_team.copy(score = Game.Score(10, 0), poss = 1), //(ignored)
+              Events.made_ft_team.copy(score = Game.Score(1, 0)),
+              Events.missed_ft_team.copy(score = Game.Score(0, 0)),
+            ) -> PossessionEnd()
+          ) ::
+          (List(
+              Events.made_ft_team.copy(score = Game.Score(0, 0)),
+              Events.missed_ft_team.copy(score = Game.Score(1, 0)),
+            ) -> PossessionContinues
+          ) ::
           Nil
 
-        val test_unclear_pairs_no_orb = //almost all events get overwritten by a poss end
-          test_event_pairs(0) ::
-          test_event_pairs(1) ::
-          test_event_pairs.drop(2).map(t2 => (t2._1, PossessionEnd(last_clump = true)))
-
-        val test_unclear_pairs_orb =
-          test_event_pairs ++ List(
-             (Events.orb_team -> PossessionContinues)
-          )
-
-        val events_that_error_team =
+        val events_that_error_team = //(check DRBs prevent errors occuring)
+          (List(Events.drb_opponent, Events.missed_opponent) -> PossessionEnd(compound_clump = true)) ::
           (List(Events.steal_team) -> PossessionError) ::
           (List(Events.missed_opponent) -> PossessionError) ::
           Nil
 
-        val events_that_error_oppo =
+        val events_that_error_oppo = //(check DRBs prevent errors occuring)
+          (List(Events.drb_team, Events.made_team) -> PossessionEnd(compound_clump = true)) ::
           (List(Events.made_team) -> PossessionError) ::
           (List(Events.turnover_team) -> PossessionError) ::
           Nil
 
         val team_state = PossState.init.copy(direction = Direction.Team)
         val oppo_state = PossState.init.copy(direction = Direction.Opponent)
-        val poss_unclear_state = team_state.copy(status = PossState.Status.Unclear)
 
         sealed trait TestCase
         case class TestCase1[T](s: PossState, l: List[(Model.PlayByPlayEvent, T)]) extends TestCase
@@ -145,9 +152,7 @@ object PossessionUtilsTests extends TestSuite with PossessionUtils {
 
         List(
           TestCase1(team_state, test_event_pairs),
-          TestCase1(oppo_state, opponent_ft_pairs),
-          TestCase1(poss_unclear_state, test_unclear_pairs_no_orb),
-          TestCase1(poss_unclear_state, test_unclear_pairs_orb),
+          TestCase2(team_state, missed_ft_events),
           TestCase2(team_state, events_that_error_team),
           TestCase2(oppo_state, events_that_error_oppo),
         ).foreach {
@@ -158,37 +163,40 @@ object PossessionUtilsTests extends TestSuite with PossessionUtils {
               }
             ) {
               case res =>
-                res ==> l.map(_._2)
+                val expected = l.map(_._2)
+                if (res != expected) {
+                  print_useful_list_diff(res, expected)
+                }
+                res ==> expected
             }
-            case TestCase2(s, ll) => ll.foreach { case (l, exp) =>
+            case TestCase2(s, ll) => ll.foreach { case (l, expected) =>
               TestUtils.inside(clump_possession_status(s, l)) {
-                case `exp` =>
+                case `expected` =>
               }
             }
         }
       }
 
       "calculate_possessions" - {
-        //TODO test cases
 
         // Test Cases 1.*: Check that correctly calculates first possession
-        // Test Cases 2.*: Check that rebounds are handled correctly
+        // Test Cases 2.*: Check that rebounds are handled correctly (including compound clumps with DRBs)
         // Test Cases 3.*: Check that possession change is handled correctly across a game break
         // Test Cases 4.*: check that missed free throws are handled correctly
         // Test Cases 5.*: Check that after a possession error everything stops
 
         val game_1_events = //Test cases 1-3
           // Jump ball, ignored (1.*)
-          Model.OtherTeamEvent(19.58, gs, 0, "19:58:00,0-0,Bruno Fernando, jumpball won") ::
-          Model.OtherOpponentEvent(19.58, gs, 0, "19:58:00,0-0,Kavell Bigby-Williams, jumpball lost") ::
+          Events.jump_won_team.copy(min = 19.58) ::
+          Events.jump_lost_opponent.copy(min = 19.58) ::
           // 1T possession - team wins jump (possession arrow to opponent) and scores (1.*)
           Events.made_team.copy(min = 19.0, poss = -1) ::
           // 1O possession - DRBs and ORBs (1.*)
           Events.missed_opponent.copy(min = 18.0, poss = -1) ::
           Events.orb_opponent.copy(min = 17.0, poss = -1) ::
           Events.missed_opponent.copy(min = 16.0, poss = -1) ::
-          // 2T possession
-          Events.drb_team.copy(min = 15.0, poss = -2) ::
+          // 2T possession (note compound clump)
+          Events.drb_team.copy(min = 16.0, poss = -2) ::
           Events.made_team.copy(min = 14.0, poss = -2) ::
           // 2O possession
           Events.made_opponent.copy(min = 13.0, poss = -2) ::
@@ -200,7 +208,8 @@ object PossessionUtilsTests extends TestSuite with PossessionUtils {
           Events.game_break.copy(min = 0.0) ::
           Nil
 
-        val error_event = Model.OtherTeamEvent(0.0, gs, 0, "00:00,0-0,POSSESSION_STATE_ERROR")
+        val gs1 = Game.Score(0, 1)
+        val gs2 = Game.Score(1, 0)
 
         val game_2_events = //Test cases 1-5
           // 1O possession - fouled and made and one (1,*, 2.*, 4.*)
@@ -214,18 +223,18 @@ object PossessionUtilsTests extends TestSuite with PossessionUtils {
           // Game break (3.*)
           Events.game_break.copy(min = 15.0) ::
           // 2T possession - fouled, missed a free throw, ends up it was the first so possession switches (2.*, 4.*)
-          Events.made_ft_team.copy(min = 14.0, poss = -2) ::
+          Events.made_ft_team.copy(min = 14.0, score = gs1, poss = -2) ::
           Events.missed_ft_team.copy(min = 14.0, poss = -2) ::
           // 3O possession - missed both free throws, ORB so possession continues (2.*, 4.*)
           Events.missed_ft_opponent.copy(min = 13.0, poss = -3) ::
           Events.missed_ft_opponent.copy(min = 13.0, poss = -3) ::
           Events.orb_opponent.copy(min = 12.0, poss = -3) ::
           // 3O possession continues - missed a free throw, this time it was the 2nd, ORB so possession continues (2.*, 4.*)
-          Events.missed_ft_opponent.copy(min = 11.0, poss = -3) ::
+          Events.missed_ft_opponent.copy(min = 11.0, score = gs2, poss = -3) ::
           Events.made_ft_opponent.copy(min = 11.0, poss = -3) ::
           Events.orb_opponent.copy(min = 10.0, poss = -3) ::
           // 3O possession continues - missed a free throw, this time it was the 2nd, DRB so possession switches (2.*, 4.*)
-          Events.missed_ft_opponent.copy(min = 9.0, poss = -3) ::
+          Events.missed_ft_opponent.copy(min = 9.0, score = gs2, poss = -3) ::
           Events.made_ft_opponent.copy(min = 9.0, poss = -3) ::
           Events.drb_team.copy(min = 8.0, poss = -3) ::
           // 3T possesion - fouled and missed FT, ORB (2.*, 4.*)
@@ -237,7 +246,7 @@ object PossessionUtilsTests extends TestSuite with PossessionUtils {
           Events.missed_ft_team.copy(min = 5.0, poss = -3) ::
           Events.drb_opponent.copy(min = 4.0, poss = -4) ::
           // Error! Everything after here should be ignored (5.*)
-          error_event ::
+          ERROR_EVENT ::
           Events.made_team.copy(min = 3.0, poss = 0) ::
           Events.made_opponent.copy(min = 2.0, poss = 0) ::
           Events.made_team.copy(min = 1.0, poss = 0) ::
@@ -246,20 +255,30 @@ object PossessionUtilsTests extends TestSuite with PossessionUtils {
         List(
           game_1_events, game_2_events
         ).foreach { test_case_events =>
-          val filtered_events = test_case_events.filter(_ != error_event)
+          val filtered_events = test_case_events.filter(_ != ERROR_EVENT)
           TestUtils.inside(calculate_possessions(filtered_events)) {
-            case l =>
-//Useful debug if assertion below fails
-//println("***********")
-//println( ( l zip test_case_events ).map(t2 => s"${t2._1} V ${t2._2}").mkString("\n") )
-//println("***********")
-              l ==> test_case_events.map {
+            case res =>
+              val expected = test_case_events.map {
                 case ev: Model.MiscGameEvent => ev.with_poss(-ev.poss)
                 case ev => ev
               }
+              if (res != expected) {
+                print_useful_list_diff(res, expected)
+              }
+              res ==> expected
           }
         }
       }
     }
+  }
+  /** (Useful debug if assertion below fails) */
+  private def print_useful_list_diff(l1: List[_], l2: List[_]): Unit = {
+    println("+++++++++++++++++++")
+    println(
+      l1.zip(l2).map {
+        t2 => s"[${t2._1}] V [${t2._2}]"
+      }.mkString("\n")
+    )
+    println("-------------------")
   }
 }

--- a/src/test/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/PossessionUtilsTests.scala
+++ b/src/test/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/PossessionUtilsTests.scala
@@ -14,52 +14,48 @@ object PossessionUtilsTests extends TestSuite with PossessionUtils {
   val tests = Tests {
     "PossessionUtils" - {
 
-      val gs = Game.Score(0, 0)
-
       /** A handy compilation of events */
       object Events {
-        val game_break = Model.GameBreakEvent(0.9)
-        val jump_won_team = Model.OtherTeamEvent(0.0, gs, 0, "19:58:00,0-0,Bruno Fernando, jumpball won")
-        val jump_won_opponent = Model.OtherOpponentEvent(0.0, gs, 0, "19:58:00,0-0,Bruno Fernando, jumpball won")
-        val jump_lost_opponent = Model.OtherOpponentEvent(0.0, gs, 0, "19:58:00,0-0,Kavell Bigby-Williams, jumpball lost")
+        val jump_won_team = LineupEvent.RawGameEvent.team(min = 0.0, s = "19:58:00,0-0,Bruno Fernando, jumpball won")
+        val jump_won_opponent = LineupEvent.RawGameEvent.opponent(min = 0.0, s = "19:58:00,0-0,Bruno Fernando, jumpball won")
+        val jump_lost_opponent = LineupEvent.RawGameEvent.opponent(min = 0.0, s = "19:58:00,0-0,Kavell Bigby-Williams, jumpball lost")
 
-        val turnover_team = Model.OtherTeamEvent(0.0, gs, 0, "08:44:00,20-23,Bruno Fernando, turnover badpass")
-        val steal_team = Model.OtherTeamEvent(0.0, gs, 0, "05:10,55-68,MASON III,FRANK Steal")
-        val made_team = Model.OtherTeamEvent(0.0, gs, 0, "10:00,51-60,SMITH,JALEN made Three Point Jumper")
-        val made_ft_team = Model.OtherTeamEvent(0.0, gs, 0, "05:10,55-68,Kevin Anderson, freethrow 2of2 made")
-        val missed_ft_team = Model.OtherTeamEvent(0.0, gs, 0, "10:00,51-60,DREAD,MYLES missed Free Throw")
-        val orb_team = Model.OtherTeamEvent(0.0, gs, 0, "10:00,51-60,Darryl Morsell, rebound offensive")
-        val drb_team = Model.OtherTeamEvent(0.0, gs, 0, "10:00,51-60,Darryl Morsell, rebound defensive")
-        val foul_team = Model.OtherTeamEvent(0.0, gs, 0, "10:00,51-60,MYKHAILIUK,SVI Commits Foul")
+        val turnover_team = LineupEvent.RawGameEvent.team(min = 0.0, s = "08:44:00,20-23,Bruno Fernando, turnover badpass")
+        val steal_team = LineupEvent.RawGameEvent.team(min = 0.0, s = "05:10,55-68,MASON III,FRANK Steal")
+        val made_team = LineupEvent.RawGameEvent.team(min = 0.0, s = "10:00,51-60,SMITH,JALEN made Three Point Jumper")
+        val made_ft_team = LineupEvent.RawGameEvent.team(min = 0.0, s = "05:10,55-68,Kevin Anderson, freethrow 2of2 made")
+        val missed_ft_team = LineupEvent.RawGameEvent.team(min = 0.0, s = "10:00,51-60,DREAD,MYLES missed Free Throw")
+        val orb_team = LineupEvent.RawGameEvent.team(min = 0.0, s = "10:00,51-60,Darryl Morsell, rebound offensive")
+        val drb_team = LineupEvent.RawGameEvent.team(min = 0.0, s = "10:00,51-60,Darryl Morsell, rebound defensive")
+        val foul_team = LineupEvent.RawGameEvent.team(min = 0.0, s = "10:00,51-60,MYKHAILIUK,SVI Commits Foul")
 
-        val made_opponent = Model.OtherOpponentEvent(0.0, gs, 0, "10:00,51-60,SMITH,JALEN made Three Point Jumper")
-        val missed_opponent = Model.OtherOpponentEvent(0.0, gs, 0, "02:28:00,27-38,Eric Ayala, 3pt jumpshot 2ndchance missed")
-        val foul_opponent = Model.OtherOpponentEvent(0.0, gs, 0, "10:00,51-60,MYKHAILIUK,SVI Commits Foul")
-        val made_ft_opponent = Model.OtherOpponentEvent(0.0, gs, 0, "05:10,55-68,Kevin Anderson, freethrow 2of2 made")
-        val missed_ft_opponent = Model.OtherOpponentEvent(0.0, gs, 0, "10:00,51-60,DREAD,MYLES missed Free Throw")
-        val steal_opponent = Model.OtherOpponentEvent(0.0, gs, 0, "05:10,55-68,MASON III,FRANK Steal")
+        val made_opponent = LineupEvent.RawGameEvent.opponent(min = 0.0, s = "10:00,51-60,SMITH,JALEN made Three Point Jumper")
+        val missed_opponent = LineupEvent.RawGameEvent.opponent(min = 0.0, s = "02:28:00,27-38,Eric Ayala, 3pt jumpshot 2ndchance missed")
+        val foul_opponent = LineupEvent.RawGameEvent.opponent(min = 0.0, s = "10:00,51-60,MYKHAILIUK,SVI Commits Foul")
+        val made_ft_opponent = LineupEvent.RawGameEvent.opponent(min = 0.0, s = "05:10,55-68,Kevin Anderson, freethrow 2of2 made")
+        val missed_ft_opponent = LineupEvent.RawGameEvent.opponent(min = 0.0, s = "10:00,51-60,DREAD,MYLES missed Free Throw")
+        val steal_opponent = LineupEvent.RawGameEvent.opponent(min = 0.0, s = "05:10,55-68,MASON III,FRANK Steal")
 
-        val orb_opponent = Model.OtherOpponentEvent(0.0, gs, 0, "10:00,51-60,Darryl Morsell, rebound offensive")
-        val drb_opponent = Model.OtherOpponentEvent(0.0, gs, 0, "10:00,51-60,Darryl Morsell, rebound defensive")
-        val tech_opponent = Model.OtherOpponentEvent(0.0, gs, 0, "06:43:00,55-79,Bruno Fernando, foul technical classa;2freethrow")
+        val orb_opponent = LineupEvent.RawGameEvent.opponent(min = 0.0, s = "10:00,51-60,Darryl Morsell, rebound offensive")
+        val drb_opponent = LineupEvent.RawGameEvent.opponent(min = 0.0, s = "10:00,51-60,Darryl Morsell, rebound defensive")
+        val tech_opponent = LineupEvent.RawGameEvent.opponent(min = 0.0, s = "06:43:00,55-79,Bruno Fernando, foul technical classa;2freethrow")
       }
 
       "concurrent_event_handler" - {
         // (test check_for_concurrent_event and rearrange_concurrent_event)
 
         val test_events @ (
-          ev1 :: ev2 :: ev3 :: ev4 :: ev_gb :: ev5 :: ev6 :: ev7
+          ev1 :: ev2 :: ev3 :: ev4 :: ev5 :: ev6 :: ev7
           :: Nil
         ) =
           // Test minutes based clumping
-          Model.OtherTeamEvent(0.4, Game.Score(0, 0), 1, "ev-1") ::
-          Model.OtherOpponentEvent(0.5, Game.Score(0, 0), 1, "ev-2") ::
-          Model.OtherTeamEvent(0.9, Game.Score(0, 0), 1, "ev-3") ::
-          Model.OtherOpponentEvent(0.9, Game.Score(0, 0), 1, "ev-4") ::
-          Model.GameBreakEvent(0.9) ::
-          Model.OtherTeamEvent(0.9, Game.Score(0, 0), 1, "ev-5") ::
-          Model.OtherOpponentEvent(0.9, Game.Score(0, 0), 1, "ev-6") ::
-          Model.OtherTeamEvent(1.0, Game.Score(0, 0), 1, "ev-7") ::
+          LineupEvent.RawGameEvent.team(min = 0.4, s = "ev-1") ::
+          LineupEvent.RawGameEvent.opponent(min = 0.5, s = "ev-2") ::
+          LineupEvent.RawGameEvent.team(min = 0.9, s = "ev-3") ::
+          LineupEvent.RawGameEvent.opponent(min = 0.9, s = "ev-4") ::
+          LineupEvent.RawGameEvent.team(min = 0.8, s = "ev-5") ::
+          LineupEvent.RawGameEvent.opponent(min = 0.8, s = "ev-6") ::
+          LineupEvent.RawGameEvent.team(min = 1.0, s = "ev-7") ::
           // Test possession directing based clumping
           Nil
         val test_events_in = test_events.map(ev => ConcurrentClump(ev :: Nil))
@@ -77,7 +73,6 @@ object PossessionUtilsTests extends TestSuite with PossessionUtils {
             ConcurrentClump(`ev1` :: Nil) ::
             ConcurrentClump(`ev2` :: Nil) ::
             ConcurrentClump(`ev3` :: `ev4` :: Nil) ::
-            ConcurrentClump(`ev_gb` :: Nil) ::
             ConcurrentClump(`ev5` :: `ev6` :: Nil) ::
             ConcurrentClump(`ev7` :: Nil) ::
             Nil
@@ -85,9 +80,12 @@ object PossessionUtilsTests extends TestSuite with PossessionUtils {
         }
       }
 
+      "protected" - {
+//TODO
+      }
 
       "calculate_possessions" - {
-
+//TODO
       }
     }
   }

--- a/src/test/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/PossessionUtilsTests.scala
+++ b/src/test/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/PossessionUtilsTests.scala
@@ -1,0 +1,102 @@
+package org.piggottfamily.cbb_explorer.utils.parsers.ncaa
+
+import utest._
+import org.joda.time.DateTime
+import org.piggottfamily.cbb_explorer.utils.TestUtils
+import org.piggottfamily.cbb_explorer.models._
+import org.piggottfamily.cbb_explorer.models.ncaa._
+
+object PossessionUtilsTests extends TestSuite with PossessionUtils {
+
+  val tests = Tests {
+    "PossessionUtils" - {
+
+//// TODO:
+/*
+
+      "calculate_possessions" - {
+        val test_events_1 = //(set expected possession -1)
+          LineupEvent.RawGameEvent(Some("19:58:00,0-0,player, jumpball lost"), None, None, None) ::
+          LineupEvent.RawGameEvent(None, Some("19:58:01,0-0,player, jumpball won"), None, None) ::
+          LineupEvent.RawGameEvent(Some("19:58:02,0-0,team1.1"), None, Some(0), None) ::
+          LineupEvent.RawGameEvent(None, Some("19:58:03,0-0,player, substitution out"), Some(0), None) ::
+          LineupEvent.RawGameEvent(Some("19:58:04,0-0,team1.2"), None, Some(0), None) ::
+          LineupEvent.RawGameEvent(None, Some("19:58:05,0-0,opp1.1"), None, Some(0)) ::
+          LineupEvent.RawGameEvent(None, Some("19:58:06,0-0,player, substitution in"), None, Some(0)) ::
+          LineupEvent.RawGameEvent(Some("19:58:07,0-0, team2.1"), None, Some(1), None) ::
+          LineupEvent.RawGameEvent(None, Some("19:58:08,0-0,PLAYER Leaves Game"), Some(1), None) ::
+          LineupEvent.RawGameEvent(None, Some("19:58:09,0-0,PLAYER Enters Game"), Some(1), None) ::
+          LineupEvent.RawGameEvent(None, Some("19:58:10,0-0,opp2.1"), None, Some(1)) ::
+          LineupEvent.RawGameEvent(Some("19:58:11,0-0,team3.1"), None, Some(2), None) ::
+          Nil
+        TestUtils.inside(calculate_possessions(test_events_1, None)) {
+          case (3, 2, events, false) =>
+            events ==> test_events_1.map(e => e.copy(
+              team_possession = e.team_possession.map(_ + 1),
+              opponent_possession = e.opponent_possession.map(_ + 1),
+            ))
+        }
+
+        val test_events_2 = LineupEvent.RawGameEvent(None, Some("19:58:00,0-0,opp1.1")) :: Nil
+        TestUtils.inside(calculate_possessions(test_events_2, None)) {
+          case (0, 1, events, false) =>
+            events ==> events.map(_.copy(opponent_possession = Some(1)))
+        }
+
+        val jumpball_event = Some("19:58:01,0-0,player, jumpball lost")
+        val timeout_event = Some("19:58:02,0-0,player, team, timeout short")
+        val block_event = Some("19:58:03,0-0,player Blocked Shot")
+        val steal_event = Some("19:58:04,0-0,player Steal")
+        val personal_foul_event = Some("19:58:05,0-0,player, foul personal; info")
+        val technical_foul_event = Some("19:58:06,0-0,player, foul technical classa; info")
+        val foul_info_event = Some("19:58:07,0-0,player, foulon")
+        val test_events_3 = //(set expected possession -1)
+          LineupEvent.RawGameEvent(Some("19:58:00,0-0,player, team1.1"), None, Some(0), None) ::
+          LineupEvent.RawGameEvent(None, jumpball_event, Some(0), None) ::
+          LineupEvent.RawGameEvent(None, timeout_event, Some(0), None) ::
+          LineupEvent.RawGameEvent(None, block_event, Some(0), None) ::
+          LineupEvent.RawGameEvent(None, steal_event, Some(0), None) ::
+          LineupEvent.RawGameEvent(None, personal_foul_event, Some(0), None) ::
+          LineupEvent.RawGameEvent(None, technical_foul_event, Some(0), None) ::
+          LineupEvent.RawGameEvent(None, foul_info_event, Some(0), None) ::
+          LineupEvent.RawGameEvent(Some("19:58:10,0-0,player, team1.2"), None, Some(0), None) ::
+          LineupEvent.RawGameEvent(None, Some("19:58:20,0-0,player, opp1.1"), None, Some(0)) ::
+          LineupEvent.RawGameEvent(jumpball_event, None, None, Some(0)) ::
+          LineupEvent.RawGameEvent(timeout_event, None, None, Some(0)) ::
+          LineupEvent.RawGameEvent(block_event, None, None, Some(0)) ::
+          LineupEvent.RawGameEvent(steal_event, None, None, Some(0)) ::
+          LineupEvent.RawGameEvent(personal_foul_event, None, None, Some(0)) ::
+          LineupEvent.RawGameEvent(technical_foul_event, None, None, Some(0)) ::
+          LineupEvent.RawGameEvent(foul_info_event, None, None, Some(0)) ::
+          LineupEvent.RawGameEvent(None, Some("19:58:30,0-0,player, opp1.2"), None, Some(0)) ::
+          Nil
+        TestUtils.inside(calculate_possessions(test_events_3, None)) {
+          case (1, 1, events, false) =>
+            events ==> test_events_3.map(e => e.copy(
+              team_possession = e.team_possession.map(_ + 1),
+              opponent_possession = e.opponent_possession.map(_ + 1),
+            ))
+        }
+
+        // Check adjustments to previous lineup:
+        val misc_team_event =
+          LineupEvent.RawGameEvent(Some("19:58:00,0-0,player, team1.2"), None, Some(0), None)
+        val misc_opponent_event =
+          LineupEvent.RawGameEvent(Some("19:58:00,0-0,player, team1.2"), None, None, Some(0))
+
+        TestUtils.inside(calculate_possessions(test_events_1, Some(misc_team_event))) {
+          case (_, _, _, true) =>
+        }
+        TestUtils.inside(calculate_possessions(test_events_1, Some(misc_opponent_event))) {
+          case (_, _, _, false) =>
+        }
+        TestUtils.inside(calculate_possessions(test_events_2, Some(misc_team_event))) {
+          case (_, _, _, false) =>
+        }
+        TestUtils.inside(calculate_possessions(test_events_2, Some(misc_opponent_event))) {
+          case (_, _, _, true) =>
+        }
+        */
+      }
+    }
+}

--- a/src/test/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/PossessionUtilsTests.scala
+++ b/src/test/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/PossessionUtilsTests.scala
@@ -45,42 +45,47 @@ object PossessionUtilsTests extends TestSuite with PossessionUtils {
         // (test check_for_concurrent_event and rearrange_concurrent_event)
 
         val test_events @ (
-          ev1 :: ev2 :: ev3 :: ev4 :: ev5 :: ev6 :: ev7
+          ev1 :: ev2 :: ev3 :: ev4 :: ev5 :: ev6 :: ev7 :: ev8
           :: Nil
         ) =
           // Test minutes based clumping
-          LineupEvent.RawGameEvent.team(min = 0.4, s = "ev-1") ::
-          LineupEvent.RawGameEvent.opponent(min = 0.5, s = "ev-2") ::
-          LineupEvent.RawGameEvent.team(min = 0.9, s = "ev-3") ::
-          LineupEvent.RawGameEvent.opponent(min = 0.9, s = "ev-4") ::
-          LineupEvent.RawGameEvent.team(min = 0.8, s = "ev-5") ::
-          LineupEvent.RawGameEvent.opponent(min = 0.8, s = "ev-6") ::
-          LineupEvent.RawGameEvent.team(min = 1.0, s = "ev-7") ::
+          LineupEvent.RawGameEvent.team(min = 0.4, s = "20:00,ev-1") ::
+          LineupEvent.RawGameEvent.opponent(min = 0.5, s = "19:00,ev-2") ::
+          LineupEvent.RawGameEvent.team(min = 0.9, s = "18:00,ev-3") ::
+          LineupEvent.RawGameEvent.opponent(min = 0.9, s = "17:00,ev-4") ::
+          LineupEvent.RawGameEvent.team(min = 0.8, s = "16:00,ev-5") ::
+          LineupEvent.RawGameEvent.opponent(min = 0.8, s = "15:00,ev-6") ::
+          //(game break!)
+          LineupEvent.RawGameEvent.opponent(min = 0.8, s = "20:00,ev-7") ::
+          LineupEvent.RawGameEvent.team(min = 1.0, s = "19:00,ev-8") ::
           // Test possession directing based clumping
           Nil
-        val test_events_in = test_events.map(ev => ConcurrentClump(ev :: Nil))
+        val test_events_in = test_events.map(ev => ConcurrentClump(ev :: Nil, Nil))
 
 
         TestUtils.inside(
           StateUtils.foldLeft(test_events_in, PossState.init, concurrent_event_handler[PossState]) {
-            case StateEvent.Next(ctx, state, ConcurrentClump(evs)) =>
+            case StateEvent.Next(ctx, state, ConcurrentClump(evs, _)) =>
               ctx.stateChange(state, ConcurrentClump(evs))
             case StateEvent.Complete(ctx, _) =>
               ctx.noChange
           }
         ) {
           case FoldStateComplete(_,
-            ConcurrentClump(`ev1` :: Nil) ::
-            ConcurrentClump(`ev2` :: Nil) ::
-            ConcurrentClump(`ev3` :: `ev4` :: Nil) ::
-            ConcurrentClump(`ev5` :: `ev6` :: Nil) ::
-            ConcurrentClump(`ev7` :: Nil) ::
+            ConcurrentClump(`ev1` :: Nil, _) ::
+            ConcurrentClump(`ev2` :: Nil, _) ::
+            ConcurrentClump(`ev3` :: `ev4` :: Nil, _) ::
+            ConcurrentClump(`ev5` :: `ev6` :: Nil, _) ::
+            ConcurrentClump(`ev7` :: Nil, _) ::
+            ConcurrentClump(`ev8` :: Nil, _) ::
             Nil
           ) =>
         }
+
+//TODO TOTEST concurrent clumps with lineups
       }
 
-      "protected" - {
+      "TODO" - {
 //TODO TOTEST
       }
 

--- a/src/test/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/PossessionUtilsTests.scala
+++ b/src/test/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/PossessionUtilsTests.scala
@@ -14,10 +14,49 @@ object PossessionUtilsTests extends TestSuite with PossessionUtils {
   val tests = Tests {
     "PossessionUtils" - {
 
+      val gs = Game.Score(0, 0)
+
+      /** A handy compilation of events */
+      object Events {
+        val game_break = Model.GameBreakEvent(0.9)
+        val jump_won_team = Model.OtherTeamEvent(0.0, gs, 0, "19:58:00,0-0,Bruno Fernando, jumpball won")
+        val jump_won_opponent = Model.OtherOpponentEvent(0.0, gs, 0, "19:58:00,0-0,Bruno Fernando, jumpball won")
+        val jump_lost_opponent = Model.OtherOpponentEvent(0.0, gs, 0, "19:58:00,0-0,Kavell Bigby-Williams, jumpball lost")
+
+        val turnover_team = Model.OtherTeamEvent(0.0, gs, 0, "08:44:00,20-23,Bruno Fernando, turnover badpass")
+        val steal_team = Model.OtherTeamEvent(0.0, gs, 0, "05:10,55-68,MASON III,FRANK Steal")
+        val made_team = Model.OtherTeamEvent(0.0, gs, 0, "10:00,51-60,SMITH,JALEN made Three Point Jumper")
+        val made_ft_team = Model.OtherTeamEvent(0.0, gs, 0, "05:10,55-68,Kevin Anderson, freethrow 2of2 made")
+        val missed_ft_team = Model.OtherTeamEvent(0.0, gs, 0, "10:00,51-60,DREAD,MYLES missed Free Throw")
+        val orb_team = Model.OtherTeamEvent(0.0, gs, 0, "10:00,51-60,Darryl Morsell, rebound offensive")
+        val drb_team = Model.OtherTeamEvent(0.0, gs, 0, "10:00,51-60,Darryl Morsell, rebound defensive")
+        val foul_team = Model.OtherTeamEvent(0.0, gs, 0, "10:00,51-60,MYKHAILIUK,SVI Commits Foul")
+
+        val made_opponent = Model.OtherOpponentEvent(0.0, gs, 0, "10:00,51-60,SMITH,JALEN made Three Point Jumper")
+        val missed_opponent = Model.OtherOpponentEvent(0.0, gs, 0, "02:28:00,27-38,Eric Ayala, 3pt jumpshot 2ndchance missed")
+        val foul_opponent = Model.OtherOpponentEvent(0.0, gs, 0, "10:00,51-60,MYKHAILIUK,SVI Commits Foul")
+        val made_ft_opponent = Model.OtherOpponentEvent(0.0, gs, 0, "05:10,55-68,Kevin Anderson, freethrow 2of2 made")
+        val missed_ft_opponent = Model.OtherOpponentEvent(0.0, gs, 0, "10:00,51-60,DREAD,MYLES missed Free Throw")
+
+        val orb_opponent = Model.OtherOpponentEvent(0.0, gs, 0, "10:00,51-60,Darryl Morsell, rebound offensive")
+        val drb_opponent = Model.OtherOpponentEvent(0.0, gs, 0, "10:00,51-60,Darryl Morsell, rebound defensive")
+        val tech_opponent = Model.OtherOpponentEvent(0.0, gs, 0, "06:43:00,55-79,Bruno Fernando, foul technical classa;2freethrow")
+
+        val missed_possession_opponent = Model.OtherOpponentEvent(1.0, gs, 0, s"10:00,51-60, $error_event_string")
+          //(linked to drb_opponent)
+
+        val unknown_team = Model.OtherTeamEvent(0.0, gs, 0, "UNKNOWN_EVENT")
+      }
+
       "concurrent_event_handler" - {
         // (test check_for_concurrent_event and rearrange_concurrent_event)
 
-        val test_events @ (ev1 :: ev2 :: ev3 :: ev4 :: ev_gb :: ev5 :: ev6 :: ev7:: Nil) =
+        val test_events @ (
+          ev1 :: ev2 :: ev3 :: ev4 :: ev_gb :: ev5 :: ev6 :: ev7
+//TODO:
+          :: Nil
+        ) =
+          // Test minutes based clumping
           Model.OtherTeamEvent(0.4, Game.Score(0, 0), 1, "ev-1") ::
           Model.OtherOpponentEvent(0.5, Game.Score(0, 0), 1, "ev-2") ::
           Model.OtherTeamEvent(0.9, Game.Score(0, 0), 1, "ev-3") ::
@@ -26,8 +65,11 @@ object PossessionUtilsTests extends TestSuite with PossessionUtils {
           Model.OtherTeamEvent(0.9, Game.Score(0, 0), 1, "ev-5") ::
           Model.OtherOpponentEvent(0.9, Game.Score(0, 0), 1, "ev-6") ::
           Model.OtherTeamEvent(1.0, Game.Score(0, 0), 1, "ev-7") ::
+          // Test possession directing based clumping
+//TODO:
           Nil
         val test_events_in = test_events.map(ev => ConcurrentClump(ev :: Nil))
+
 
         TestUtils.inside(
           StateUtils.foldLeft(test_events_in, PossState.init, concurrent_event_handler) {
@@ -49,41 +91,16 @@ object PossessionUtilsTests extends TestSuite with PossessionUtils {
         }
       }
 
-      val gs = Game.Score(0, 0)
-
-      /** A handy compilation of events */
-      object Events {
-        val game_break = Model.GameBreakEvent(0.9)
-        val jump_won_team = Model.OtherTeamEvent(0.0, gs, 0, "19:58:00,0-0,Bruno Fernando, jumpball won")
-        val jump_lost_opponent = Model.OtherOpponentEvent(0.0, gs, 0, "19:58:00,0-0,Kavell Bigby-Williams, jumpball lost")
-
-        val turnover_team = Model.OtherTeamEvent(0.0, gs, 0, "08:44:00,20-23,Bruno Fernando, turnover badpass")
-        val steal_team = Model.OtherTeamEvent(0.0, gs, 0, "05:10,55-68,MASON III,FRANK Steal")
-        val made_team = Model.OtherTeamEvent(0.0, gs, 0, "10:00,51-60,SMITH,JALEN made Three Point Jumper")
-        val made_ft_team = Model.OtherTeamEvent(0.0, gs, 0, "05:10,55-68,Kevin Anderson, freethrow 2of2 made")
-        val missed_ft_team = Model.OtherTeamEvent(0.0, gs, 0, "10:00,51-60,DREAD,MYLES missed Free Throw")
-        val orb_team = Model.OtherTeamEvent(0.0, gs, 0, "10:00,51-60,Darryl Morsell, rebound offensive")
-        val drb_team = Model.OtherTeamEvent(0.0, gs, 0, "10:00,51-60,Darryl Morsell, rebound defensive")
-
-        val made_opponent = Model.OtherOpponentEvent(0.0, gs, 0, "10:00,51-60,SMITH,JALEN made Three Point Jumper")
-        val missed_opponent = Model.OtherOpponentEvent(0.0, gs, 0, "02:28:00,27-38,Eric Ayala, 3pt jumpshot 2ndchance missed")
-        val foul_opponent = Model.OtherOpponentEvent(0.0, gs, 0, "10:00,51-60,MYKHAILIUK,SVI Commits Foul")
-        val made_ft_opponent = Model.OtherOpponentEvent(0.0, gs, 0, "05:10,55-68,Kevin Anderson, freethrow 2of2 made")
-        val missed_ft_opponent = Model.OtherOpponentEvent(0.0, gs, 0, "10:00,51-60,DREAD,MYLES missed Free Throw")
-
-        val orb_opponent = Model.OtherOpponentEvent(0.0, gs, 0, "10:00,51-60,Darryl Morsell, rebound offensive")
-        val drb_opponent = Model.OtherOpponentEvent(0.0, gs, 0, "10:00,51-60,Darryl Morsell, rebound defensive")
-        val tech_opponent = Model.OtherOpponentEvent(0.0, gs, 0, "06:43:00,55-79,Bruno Fernando, foul technical classa;2freethrow")
-
-        val unknown_team = Model.OtherTeamEvent(0.0, gs, 0, "UNKNOWN_EVENT")
-      }
-
       "first_possession_status" - {
         val test_event_pairs =
+          (Events.jump_won_team -> Some(Direction.Team)) ::
+          (Events.jump_won_opponent -> Some(Direction.Opponent)) ::
           (Events.turnover_team -> Some(Direction.Team)) ::
           (Events.steal_team -> Some(Direction.Opponent)) ::
+          (Events.made_team -> Some(Direction.Team)) ::
+          (Events.missed_ft_team -> Some(Direction.Team)) ::
           (Events.missed_opponent -> Some(Direction.Opponent)) ::
-          (Events.foul_opponent -> Some(Direction.Team)) ::
+          (Events.made_ft_opponent -> Some(Direction.Opponent)) ::
           (Events.unknown_team -> None) ::
           Nil
 
@@ -106,15 +123,20 @@ object PossessionUtilsTests extends TestSuite with PossessionUtils {
         val test_event_pairs =
           (Events.drb_opponent.copy(poss = 1) -> PossessionArrowSwitch) :: //(is ignored)
           (Events.game_break -> PossessionArrowSwitch) ::
-          (Events.drb_opponent -> PossessionEnd(compound_clump = true)) ::
-          (Events.turnover_team -> PossessionEnd()) ::
+          (Events.drb_opponent -> PossessionEnd) ::
+          (Events.turnover_team -> PossessionEnd) ::
           (Events.tech_opponent -> PossessionContinues) ::
           (Events.made_team -> PossessionContinues) :: //(cos of the missed and one next)
           (Events.missed_ft_team -> PossessionContinues) ::
-          (Events.made_team -> PossessionEnd()) ::
-          (Events.made_ft_team -> PossessionEnd()) :: //(no missed FTs follow)
-          (Events.made_team -> PossessionEnd()) :: //(no FTs after)
+          (Events.made_team -> PossessionEnd) ::
+          (Events.made_ft_team -> PossessionEnd) :: //(no missed FTs follow)
+          (Events.made_team -> PossessionEnd) :: //(no FTs after)
           (Events.unknown_team -> PossessionContinues) :: //(no FTs after)
+          Nil
+
+        val turnover_events =
+          (List(Events.turnover_team) -> PossessionEnd) ::
+          (List(Events.foul_team) -> PossessionEnd) ::
           Nil
 
         val missed_ft_events =
@@ -122,7 +144,7 @@ object PossessionUtilsTests extends TestSuite with PossessionUtils {
               Events.missed_ft_team.copy(score = Game.Score(10, 0), poss = 1), //(ignored)
               Events.made_ft_team.copy(score = Game.Score(1, 0)),
               Events.missed_ft_team.copy(score = Game.Score(0, 0)),
-            ) -> PossessionEnd()
+            ) -> PossessionEnd
           ) ::
           (List(
               Events.made_ft_team.copy(score = Game.Score(0, 0)),
@@ -132,13 +154,12 @@ object PossessionUtilsTests extends TestSuite with PossessionUtils {
           Nil
 
         val events_that_error_team = //(check DRBs prevent errors occuring)
-          (List(Events.drb_opponent, Events.missed_opponent) -> PossessionEnd(compound_clump = true)) ::
           (List(Events.steal_team) -> PossessionError) ::
           (List(Events.missed_opponent) -> PossessionError) ::
           Nil
 
         val events_that_error_oppo = //(check DRBs prevent errors occuring)
-          (List(Events.drb_team, Events.made_team) -> PossessionEnd(compound_clump = true)) ::
+          (List(Events.drb_team, Events.made_team) -> PossessionEnd) ::
           (List(Events.made_team) -> PossessionError) ::
           (List(Events.turnover_team) -> PossessionError) ::
           Nil
@@ -152,9 +173,10 @@ object PossessionUtilsTests extends TestSuite with PossessionUtils {
 
         List(
           TestCase1(team_state, test_event_pairs),
+          TestCase2(team_state, turnover_events),
           TestCase2(team_state, missed_ft_events),
           TestCase2(team_state, events_that_error_team),
-          TestCase2(oppo_state, events_that_error_oppo),
+          TestCase2(oppo_state, events_that_error_oppo)
         ).foreach {
           case TestCase1(s, l) =>
             TestUtils.inside(
@@ -171,7 +193,13 @@ object PossessionUtilsTests extends TestSuite with PossessionUtils {
             }
             case TestCase2(s, ll) => ll.foreach { case (l, expected) =>
               TestUtils.inside(clump_possession_status(s, l)) {
-                case `expected` =>
+                case res =>
+                  if (res != expected) {
+                    println("+++++++++++++++++++")
+                    println(s"[$l] vs [$res]")
+                    println("-------------------")
+                  }
+                  res ==> expected
               }
             }
         }
@@ -187,16 +215,16 @@ object PossessionUtilsTests extends TestSuite with PossessionUtils {
 
         val game_1_events = //Test cases 1-3
           // Jump ball, ignored (1.*)
-          Events.jump_won_team.copy(min = 19.58) ::
-          Events.jump_lost_opponent.copy(min = 19.58) ::
+          Events.jump_won_team.copy(min = 19.58, poss = -1) ::
+          Events.jump_lost_opponent.copy(min = 19.58, poss = -1) ::
           // 1T possession - team wins jump (possession arrow to opponent) and scores (1.*)
           Events.made_team.copy(min = 19.0, poss = -1) ::
           // 1O possession - DRBs and ORBs (1.*)
           Events.missed_opponent.copy(min = 18.0, poss = -1) ::
           Events.orb_opponent.copy(min = 17.0, poss = -1) ::
           Events.missed_opponent.copy(min = 16.0, poss = -1) ::
+          Events.drb_team.copy(min = 16.0, poss = -1) :: //(DRB belongs to end of offensive possession)
           // 2T possession (note compound clump)
-          Events.drb_team.copy(min = 16.0, poss = -2) ::
           Events.made_team.copy(min = 14.0, poss = -2) ::
           // 2O possession
           Events.made_opponent.copy(min = 13.0, poss = -2) ::
@@ -244,18 +272,21 @@ object PossessionUtilsTests extends TestSuite with PossessionUtils {
           // 3T possesion - fouled and missed FT, DRB (2.*, 4.*)
           Events.made_team.copy(min = 5.0, poss = -3) ::
           Events.missed_ft_team.copy(min = 5.0, poss = -3) ::
-          Events.drb_opponent.copy(min = 4.0, poss = -4) ::
-          // Error! Everything after here should be ignored (5.*)
-          ERROR_EVENT ::
-          Events.made_team.copy(min = 3.0, poss = 0) ::
-          Events.made_opponent.copy(min = 2.0, poss = 0) ::
-          Events.made_team.copy(min = 1.0, poss = 0) ::
+          Events.drb_opponent.copy(min = 4.0, poss = -3) ::
+          // Handle missed possesion (5.x)
+          Events.missed_possession_opponent.copy(min = 3.0, poss = -4) ::
+          Events.made_team.copy(min = 3.0, poss = -4) ::
+          Events.made_opponent.copy(min = 1.0, poss = -5) :: //(5.x check compound clumps)
+          Events.made_team.copy(min = 1.0, poss = -5) ::
           Nil
 
         List(
           game_1_events, game_2_events
         ).foreach { test_case_events =>
-          val filtered_events = test_case_events.filter(_ != ERROR_EVENT)
+          val filtered_events = test_case_events.filter {
+            case ev: Model.MiscGameEvent if ev.event_string.contains(error_event_string) => false
+            case _ => true
+          }
           TestUtils.inside(calculate_possessions(filtered_events)) {
             case res =>
               val expected = test_case_events.map {
@@ -275,8 +306,9 @@ object PossessionUtilsTests extends TestSuite with PossessionUtils {
   private def print_useful_list_diff(l1: List[_], l2: List[_]): Unit = {
     println("+++++++++++++++++++")
     println(
-      l1.zip(l2).map {
-        t2 => s"[${t2._1}] V [${t2._2}]"
+      l1.zip(l2).map { t2 =>
+        val are_eq = if (t2._1 == t2._2) "T" else "F"
+        s"[$are_eq]: [${t2._1}] V [${t2._2}]"
       }.mkString("\n")
     )
     println("-------------------")

--- a/src/test/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/PossessionUtilsTests.scala
+++ b/src/test/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/PossessionUtilsTests.scala
@@ -62,7 +62,7 @@ object PossessionUtilsTests extends TestSuite with PossessionUtils {
 
 
         TestUtils.inside(
-          StateUtils.foldLeft(test_events_in, PossState.init, concurrent_event_handler) {
+          StateUtils.foldLeft(test_events_in, PossState.init, concurrent_event_handler[PossState]) {
             case StateEvent.Next(ctx, state, ConcurrentClump(evs)) =>
               ctx.stateChange(state, ConcurrentClump(evs))
             case StateEvent.Complete(ctx, _) =>
@@ -81,11 +81,11 @@ object PossessionUtilsTests extends TestSuite with PossessionUtils {
       }
 
       "protected" - {
-//TODO
+//TODO TOTEST
       }
 
       "calculate_possessions" - {
-//TODO
+//TODO TOTEST
       }
     }
   }

--- a/src/test/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/PossessionUtilsTests.scala
+++ b/src/test/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/PossessionUtilsTests.scala
@@ -2,101 +2,177 @@ package org.piggottfamily.cbb_explorer.utils.parsers.ncaa
 
 import utest._
 import org.joda.time.DateTime
+import org.piggottfamily.utils.StateUtils
 import org.piggottfamily.cbb_explorer.utils.TestUtils
 import org.piggottfamily.cbb_explorer.models._
 import org.piggottfamily.cbb_explorer.models.ncaa._
 
 object PossessionUtilsTests extends TestSuite with PossessionUtils {
+  import ExtractorUtils._
+  import StateUtils.StateTypes._
 
   val tests = Tests {
     "PossessionUtils" - {
 
-//// TODO:
-/*
+      "concurrent_event_handler" - {
+        // (test check_for_concurrent_event and rearrange_concurrent_event)
+
+        val test_events @ (ev1 :: ev2 :: ev3 :: ev4 :: ev_gb :: ev5 :: ev6 :: ev7:: Nil) =
+          Model.OtherTeamEvent(0.4, Game.Score(0, 0), 1, "ev-1") ::
+          Model.OtherOpponentEvent(0.5, Game.Score(0, 0), 1, "ev-2") ::
+          Model.OtherTeamEvent(0.9, Game.Score(0, 0), 1, "ev-3") ::
+          Model.OtherOpponentEvent(0.9, Game.Score(0, 0), 1, "ev-4") ::
+          Model.GameBreakEvent(0.9) ::
+          Model.OtherTeamEvent(0.9, Game.Score(0, 0), 1, "ev-5") ::
+          Model.OtherOpponentEvent(0.9, Game.Score(0, 0), 1, "ev-6") ::
+          Model.OtherTeamEvent(1.0, Game.Score(0, 0), 1, "ev-7") ::
+          Nil
+        val test_events_in = test_events.map(ev => ConcurrentClump(ev :: Nil))
+
+        TestUtils.inside(
+          StateUtils.foldLeft(test_events_in, PossState.init, concurrent_event_handler) {
+            case StateEvent.Next(ctx, state, ConcurrentClump(evs)) =>
+              ctx.stateChange(state, ConcurrentClump(evs))
+            case StateEvent.Complete(ctx, _) =>
+              ctx.noChange
+          }
+        ) {
+          case FoldStateComplete(_,
+            ConcurrentClump(`ev1` :: Nil) ::
+            ConcurrentClump(`ev2` :: Nil) ::
+            ConcurrentClump(`ev3` :: `ev4` :: Nil) ::
+            ConcurrentClump(`ev_gb` :: Nil) ::
+            ConcurrentClump(`ev5` :: `ev6` :: Nil) ::
+            ConcurrentClump(`ev7` :: Nil) ::
+            Nil
+          ) =>
+        }
+      }
+
+      val gs = Game.Score(0, 0)
+
+      /** A handy compilation of events */
+      object Events {
+        val game_break = Model.GameBreakEvent(0.9)
+
+        val turnover_team = Model.OtherTeamEvent(0.0, gs, 0, "08:44:00,20-23,Bruno Fernando, turnover badpass")
+        val steal_team = Model.OtherTeamEvent(0.0, gs, 1, "05:10,55-68,MASON III,FRANK Steal")
+        val made_team = Model.OtherTeamEvent(0.0, gs, 1, "10:00,51-60,SMITH,JALEN made Three Point Jumper")
+        val made_ft_team = Model.OtherTeamEvent(0.0, gs, 1, "05:10,55-68,Kevin Anderson, freethrow 2of2 made")
+        val missed_ft_team = Model.OtherTeamEvent(0.0, gs, 1, "10:00,51-60,DREAD,MYLES missed Free Throw")
+        val orb_team = Model.OtherTeamEvent(0.0, gs, 0, "10:00,51-60,Darryl Morsell, rebound offensive")
+
+        val miss_opponent = Model.OtherOpponentEvent(0.0, gs, 0, "02:28:00,27-38,Eric Ayala, 3pt jumpshot 2ndchance missed")
+        val foul_opponent = Model.OtherOpponentEvent(0.0, gs, 0, "10:00,51-60,MYKHAILIUK,SVI Commits Foul")
+        val made_ft_opponent = Model.OtherOpponentEvent(0.0, gs, 1, "05:10,55-68,Kevin Anderson, freethrow 2of2 made")
+        val missed_ft_opponent = Model.OtherOpponentEvent(0.0, gs, 1, "10:00,51-60,DREAD,MYLES missed Free Throw")
+
+        val drb_opponent = Model.OtherOpponentEvent(0.0, gs, 0, "10:00,51-60,Darryl Morsell, rebound defensive")
+        val tech_opponent = Model.OtherOpponentEvent(0.0, gs, 0, "06:43:00,55-79,Bruno Fernando, foul technical classa;2freethrow")
+
+        val unknown_team = Model.OtherTeamEvent(0.0, gs, 0, "UNKNOWN_EVENT")
+      }
+
+      "first_possession_status" - {
+        val test_event_pairs =
+          (Events.turnover_team -> Some(Direction.Team)) ::
+          (Events.steal_team -> Some(Direction.Opponent)) ::
+          (Events.miss_opponent -> Some(Direction.Opponent)) ::
+          (Events.foul_opponent -> Some(Direction.Team)) ::
+          (Events.unknown_team -> None) ::
+          Nil
+
+        TestUtils.inside(
+          test_event_pairs.zipWithIndex.map(_._2).map { test_index =>
+            first_possession_status(test_event_pairs.drop(test_index).map(_._1))
+          }
+        ) {
+          case l =>
+            l ==> test_event_pairs.map(_._2)
+        }
+      }
+
+      "clump_possession_status" - {
+
+        val test_event_pairs =
+          (Events.game_break -> PossessionArrowSwitch) ::
+          (Events.drb_opponent -> PossessionEnd(last_clump = true)) ::
+          (Events.turnover_team -> PossessionEnd()) ::
+          (Events.tech_opponent -> PossessionContinues) ::
+          (Events.made_team -> PossessionContinues) :: //(cos of the missed and one next)
+          (Events.missed_ft_team -> PossessionContinues) :: //(_not_ unclear because of shot makes ahead)
+          (Events.made_team -> PossessionEnd()) ::
+          (Events.made_ft_team -> PossessionEnd()) :: //(no missed FTs follow)
+          (Events.made_team -> PossessionEnd()) :: //(no FTs after)
+          (Events.unknown_team -> PossessionContinues) :: //(no FTs after)
+          Nil
+
+        val opponent_ft_pairs =
+          (Events.made_ft_opponent -> PossessionUnclear) ::
+          (Events.missed_ft_opponent -> PossessionContinues) ::
+          Nil
+
+        val test_unclear_pairs_no_orb = //almost all events get overwritten by a poss end
+          test_event_pairs(0) ::
+          test_event_pairs(1) ::
+          test_event_pairs.drop(2).map(t2 => (t2._1, PossessionEnd(last_clump = true)))
+
+        val test_unclear_pairs_orb =
+          test_event_pairs ++ List(
+             (Events.orb_team -> PossessionContinues)
+          )
+
+        val events_that_error_team =
+          (List(Events.steal_team) -> PossessionError) ::
+          (List(Events.miss_opponent) -> PossessionError) ::
+          Nil
+
+        val events_that_error_oppo =
+          (List(Events.made_team) -> PossessionError) ::
+          (List(Events.turnover_team) -> PossessionError) ::
+          Nil
+
+        val team_state = PossState.init.copy(direction = Direction.Team)
+        val oppo_state = PossState.init.copy(direction = Direction.Opponent)
+        val poss_unclear_state = team_state.copy(status = PossState.Status.Unclear)
+
+        sealed trait TestCase
+        case class TestCase1[T](s: PossState, l: List[(Model.PlayByPlayEvent, T)]) extends TestCase
+        case class TestCase2[T](s: PossState, l: List[(List[Model.PlayByPlayEvent], T)]) extends TestCase
+
+        List(
+          TestCase1(team_state, test_event_pairs),
+          TestCase1(oppo_state, opponent_ft_pairs),
+          TestCase1(poss_unclear_state, test_unclear_pairs_no_orb),
+          TestCase1(poss_unclear_state, test_unclear_pairs_orb),
+          TestCase2(team_state, events_that_error_team),
+          TestCase2(oppo_state, events_that_error_oppo),
+        ).foreach {
+          case TestCase1(s, l) =>
+            TestUtils.inside(
+              l.zipWithIndex.map(_._2).map { test_index =>
+                clump_possession_status(s, l.drop(test_index).map(_._1))
+              }
+            ) {
+              case res =>
+                res ==> l.map(_._2)
+            }
+            case TestCase2(s, ll) => ll.foreach { case (l, exp) =>
+              TestUtils.inside(clump_possession_status(s, l)) {
+                case `exp` =>
+              }
+            }
+        }
+      }
 
       "calculate_possessions" - {
-        val test_events_1 = //(set expected possession -1)
-          LineupEvent.RawGameEvent(Some("19:58:00,0-0,player, jumpball lost"), None, None, None) ::
-          LineupEvent.RawGameEvent(None, Some("19:58:01,0-0,player, jumpball won"), None, None) ::
-          LineupEvent.RawGameEvent(Some("19:58:02,0-0,team1.1"), None, Some(0), None) ::
-          LineupEvent.RawGameEvent(None, Some("19:58:03,0-0,player, substitution out"), Some(0), None) ::
-          LineupEvent.RawGameEvent(Some("19:58:04,0-0,team1.2"), None, Some(0), None) ::
-          LineupEvent.RawGameEvent(None, Some("19:58:05,0-0,opp1.1"), None, Some(0)) ::
-          LineupEvent.RawGameEvent(None, Some("19:58:06,0-0,player, substitution in"), None, Some(0)) ::
-          LineupEvent.RawGameEvent(Some("19:58:07,0-0, team2.1"), None, Some(1), None) ::
-          LineupEvent.RawGameEvent(None, Some("19:58:08,0-0,PLAYER Leaves Game"), Some(1), None) ::
-          LineupEvent.RawGameEvent(None, Some("19:58:09,0-0,PLAYER Enters Game"), Some(1), None) ::
-          LineupEvent.RawGameEvent(None, Some("19:58:10,0-0,opp2.1"), None, Some(1)) ::
-          LineupEvent.RawGameEvent(Some("19:58:11,0-0,team3.1"), None, Some(2), None) ::
-          Nil
-        TestUtils.inside(calculate_possessions(test_events_1, None)) {
-          case (3, 2, events, false) =>
-            events ==> test_events_1.map(e => e.copy(
-              team_possession = e.team_possession.map(_ + 1),
-              opponent_possession = e.opponent_possession.map(_ + 1),
-            ))
-        }
+        //TODO test cases
 
-        val test_events_2 = LineupEvent.RawGameEvent(None, Some("19:58:00,0-0,opp1.1")) :: Nil
-        TestUtils.inside(calculate_possessions(test_events_2, None)) {
-          case (0, 1, events, false) =>
-            events ==> events.map(_.copy(opponent_possession = Some(1)))
-        }
-
-        val jumpball_event = Some("19:58:01,0-0,player, jumpball lost")
-        val timeout_event = Some("19:58:02,0-0,player, team, timeout short")
-        val block_event = Some("19:58:03,0-0,player Blocked Shot")
-        val steal_event = Some("19:58:04,0-0,player Steal")
-        val personal_foul_event = Some("19:58:05,0-0,player, foul personal; info")
-        val technical_foul_event = Some("19:58:06,0-0,player, foul technical classa; info")
-        val foul_info_event = Some("19:58:07,0-0,player, foulon")
-        val test_events_3 = //(set expected possession -1)
-          LineupEvent.RawGameEvent(Some("19:58:00,0-0,player, team1.1"), None, Some(0), None) ::
-          LineupEvent.RawGameEvent(None, jumpball_event, Some(0), None) ::
-          LineupEvent.RawGameEvent(None, timeout_event, Some(0), None) ::
-          LineupEvent.RawGameEvent(None, block_event, Some(0), None) ::
-          LineupEvent.RawGameEvent(None, steal_event, Some(0), None) ::
-          LineupEvent.RawGameEvent(None, personal_foul_event, Some(0), None) ::
-          LineupEvent.RawGameEvent(None, technical_foul_event, Some(0), None) ::
-          LineupEvent.RawGameEvent(None, foul_info_event, Some(0), None) ::
-          LineupEvent.RawGameEvent(Some("19:58:10,0-0,player, team1.2"), None, Some(0), None) ::
-          LineupEvent.RawGameEvent(None, Some("19:58:20,0-0,player, opp1.1"), None, Some(0)) ::
-          LineupEvent.RawGameEvent(jumpball_event, None, None, Some(0)) ::
-          LineupEvent.RawGameEvent(timeout_event, None, None, Some(0)) ::
-          LineupEvent.RawGameEvent(block_event, None, None, Some(0)) ::
-          LineupEvent.RawGameEvent(steal_event, None, None, Some(0)) ::
-          LineupEvent.RawGameEvent(personal_foul_event, None, None, Some(0)) ::
-          LineupEvent.RawGameEvent(technical_foul_event, None, None, Some(0)) ::
-          LineupEvent.RawGameEvent(foul_info_event, None, None, Some(0)) ::
-          LineupEvent.RawGameEvent(None, Some("19:58:30,0-0,player, opp1.2"), None, Some(0)) ::
-          Nil
-        TestUtils.inside(calculate_possessions(test_events_3, None)) {
-          case (1, 1, events, false) =>
-            events ==> test_events_3.map(e => e.copy(
-              team_possession = e.team_possession.map(_ + 1),
-              opponent_possession = e.opponent_possession.map(_ + 1),
-            ))
-        }
-
-        // Check adjustments to previous lineup:
-        val misc_team_event =
-          LineupEvent.RawGameEvent(Some("19:58:00,0-0,player, team1.2"), None, Some(0), None)
-        val misc_opponent_event =
-          LineupEvent.RawGameEvent(Some("19:58:00,0-0,player, team1.2"), None, None, Some(0))
-
-        TestUtils.inside(calculate_possessions(test_events_1, Some(misc_team_event))) {
-          case (_, _, _, true) =>
-        }
-        TestUtils.inside(calculate_possessions(test_events_1, Some(misc_opponent_event))) {
-          case (_, _, _, false) =>
-        }
-        TestUtils.inside(calculate_possessions(test_events_2, Some(misc_team_event))) {
-          case (_, _, _, false) =>
-        }
-        TestUtils.inside(calculate_possessions(test_events_2, Some(misc_opponent_event))) {
-          case (_, _, _, true) =>
-        }
-        */
+        // Test Cases 1.*: Check that correctly calculates first possession
+        // Test Cases 2.*: Check that possession change is handled correctly across a game break
+        // Test Cases 3.*: Check that rebounds are handled correctly
+        // Test Cases 4.*: Check that after a possession error everything stops        
       }
     }
+  }
 }

--- a/src/test/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/PossessionUtilsTests.scala
+++ b/src/test/scala/org/piggottfamily/cbb_explorer/utils/parsers/ncaa/PossessionUtilsTests.scala
@@ -17,29 +17,66 @@ object PossessionUtilsTests extends TestSuite with PossessionUtils {
       /** A handy compilation of events */
       object Events {
         val jump_won_team = LineupEvent.RawGameEvent.team(min = 0.0, s = "19:58:00,0-0,Bruno Fernando, jumpball won")
-        val jump_won_opponent = LineupEvent.RawGameEvent.opponent(min = 0.0, s = "19:58:00,0-0,Bruno Fernando, jumpball won")
+        val jump_won_opponent = LineupEvent.RawGameEvent.opponent(min = 0.0, s = jump_won_team.team.get)
         val jump_lost_opponent = LineupEvent.RawGameEvent.opponent(min = 0.0, s = "19:58:00,0-0,Kavell Bigby-Williams, jumpball lost")
 
         val turnover_team = LineupEvent.RawGameEvent.team(min = 0.0, s = "08:44:00,20-23,Bruno Fernando, turnover badpass")
+        val turnover_opponent = LineupEvent.RawGameEvent.opponent(min = 0.0, s = turnover_team.team.get)
         val steal_team = LineupEvent.RawGameEvent.team(min = 0.0, s = "05:10,55-68,MASON III,FRANK Steal")
+        val steal_opponent = LineupEvent.RawGameEvent.opponent(min = 0.0, s = steal_team.team.get)
+
         val made_team = LineupEvent.RawGameEvent.team(min = 0.0, s = "10:00,51-60,SMITH,JALEN made Three Point Jumper")
-        val made_ft_team = LineupEvent.RawGameEvent.team(min = 0.0, s = "05:10,55-68,Kevin Anderson, freethrow 2of2 made")
+        val made_opponent = LineupEvent.RawGameEvent.opponent(min = 0.0, s = made_team.team.get)
+        val missed_team = LineupEvent.RawGameEvent.team(min = 0.0, s = "02:28:00,27-38,Eric Ayala, 3pt jumpshot 2ndchance missed")
+        val missed_opponent = LineupEvent.RawGameEvent.opponent(min = 0.0, s = missed_team.team.get)
+        val made_ft_team = LineupEvent.RawGameEvent.team(min = 0.0, s = "10:00,51-60,DREAD,MYLES made Free Throw")
+        val made_ft_opponent = LineupEvent.RawGameEvent.opponent(min = 0.0, s = made_ft_team.team.get)
+        val made_ft1_team = LineupEvent.RawGameEvent.team(min = 0.0, s = "05:10,55-68,Kevin Anderson, freethrow 1of2 made")
+        val made_ft1_opponent = LineupEvent.RawGameEvent.opponent(min = 0.0, s = made_ft1_team.team.get)
+        val made_ft2_team = LineupEvent.RawGameEvent.team(min = 0.0, s = "05:10,55-68,Kevin Anderson, freethrow 2of2 made")
+        val made_ft2_opponent = LineupEvent.RawGameEvent.opponent(min = 0.0, s = made_ft2_team.team.get)
         val missed_ft_team = LineupEvent.RawGameEvent.team(min = 0.0, s = "10:00,51-60,DREAD,MYLES missed Free Throw")
+        val missed_ft_opponent = LineupEvent.RawGameEvent.opponent(min = 0.0, s = missed_ft_team.team.get)
+        val missed_ft1_team = LineupEvent.RawGameEvent.team(min = 0.0, s = "05:10,55-68,Kevin Anderson, freethrow 1of2 missed")
+        val missed_ft1_opponent = LineupEvent.RawGameEvent.opponent(min = 0.0, s = missed_ft1_team.team.get)
+        val missed_ft2_team = LineupEvent.RawGameEvent.team(min = 0.0, s = "05:10,55-68,Kevin Anderson, freethrow 2of2 missed")
+        val missed_ft2_opponent = LineupEvent.RawGameEvent.opponent(min = 0.0, s = missed_ft2_team.team.get)
+
         val orb_team = LineupEvent.RawGameEvent.team(min = 0.0, s = "10:00,51-60,Darryl Morsell, rebound offensive")
+        val orb_opponent = LineupEvent.RawGameEvent.opponent(min = 0.0, s = orb_team.team.get)
         val drb_team = LineupEvent.RawGameEvent.team(min = 0.0, s = "10:00,51-60,Darryl Morsell, rebound defensive")
+        val drb_opponent = LineupEvent.RawGameEvent.opponent(min = 0.0, s = drb_team.team.get)
+        val deadball_rb_team = LineupEvent.RawGameEvent.team(min = 0.0, s = "10:00,51-60,TEAM Deadball Rebound")
+        val deadball_rb_opponent = LineupEvent.RawGameEvent.opponent(min = 0.0, s = deadball_rb_team.team.get)
+        val deadball_orb_team = LineupEvent.RawGameEvent.team(min = 0.0, s = "04:28:0,52-59,Team, rebound offensivedeadball")
+        val deadball_orb_opponent = LineupEvent.RawGameEvent.opponent(min = 0.0, s = deadball_orb_team.team.get)
+
         val foul_team = LineupEvent.RawGameEvent.team(min = 0.0, s = "10:00,51-60,MYKHAILIUK,SVI Commits Foul")
-
-        val made_opponent = LineupEvent.RawGameEvent.opponent(min = 0.0, s = "10:00,51-60,SMITH,JALEN made Three Point Jumper")
-        val missed_opponent = LineupEvent.RawGameEvent.opponent(min = 0.0, s = "02:28:00,27-38,Eric Ayala, 3pt jumpshot 2ndchance missed")
-        val foul_opponent = LineupEvent.RawGameEvent.opponent(min = 0.0, s = "10:00,51-60,MYKHAILIUK,SVI Commits Foul")
-        val made_ft_opponent = LineupEvent.RawGameEvent.opponent(min = 0.0, s = "05:10,55-68,Kevin Anderson, freethrow 2of2 made")
-        val missed_ft_opponent = LineupEvent.RawGameEvent.opponent(min = 0.0, s = "10:00,51-60,DREAD,MYLES missed Free Throw")
-        val steal_opponent = LineupEvent.RawGameEvent.opponent(min = 0.0, s = "05:10,55-68,MASON III,FRANK Steal")
-
-        val orb_opponent = LineupEvent.RawGameEvent.opponent(min = 0.0, s = "10:00,51-60,Darryl Morsell, rebound offensive")
-        val drb_opponent = LineupEvent.RawGameEvent.opponent(min = 0.0, s = "10:00,51-60,Darryl Morsell, rebound defensive")
-        val tech_opponent = LineupEvent.RawGameEvent.opponent(min = 0.0, s = "06:43:00,55-79,Bruno Fernando, foul technical classa;2freethrow")
+        val foul_opponent = LineupEvent.RawGameEvent.opponent(min = 0.0, s = foul_team.team.get)
+        val tech_team = LineupEvent.RawGameEvent.team(min = 0.0, s = "06:43:00,55-79,Bruno Fernando, foul technical classa;2freethrow")
+        val tech_opponent = LineupEvent.RawGameEvent.opponent(min = 0.0, s = tech_team.team.get)
+        val flagrant_team = LineupEvent.RawGameEvent.team(min = 0.0, s = "03:42:00,55-79,Eric Carter, foul personal flagrant1;2freethrow")
+        val flagrant_opponent = LineupEvent.RawGameEvent.opponent(min = 0.0, s = flagrant_team.team.get)
       }
+      val base_lineup = LineupEvent(
+        date = new DateTime(),
+        location_type = Game.LocationType.Home,
+        start_min = 0.0,
+        end_min = 1.0,
+        duration_mins = 0.0,
+        score_info = LineupEvent.ScoreInfo(
+          Game.Score(1, 1), Game.Score(3, 2), 2, 1
+        ),
+        team = TeamSeasonId(TeamId("TeamA"), Year(2017)),
+        opponent = TeamSeasonId(TeamId("TeamB"), Year(2017)),
+        lineup_id = LineupEvent.LineupId.unknown,
+        players = Nil,
+        players_in = Nil,
+        players_out = Nil,
+        raw_game_events = Nil,
+        team_stats = LineupEventStats.empty,
+        opponent_stats = LineupEventStats.empty
+      )
 
       "concurrent_event_handler" - {
         // (test check_for_concurrent_event and rearrange_concurrent_event)
@@ -82,11 +119,238 @@ object PossessionUtilsTests extends TestSuite with PossessionUtils {
           ) =>
         }
 
-//TODO TOTEST concurrent clumps with lineups
+        // Check with lineups:
+        val lineup1 = base_lineup.copy(start_min = 1.0, end_min = 2.0)
+        val lineup2 = base_lineup.copy(start_min = 2.0, end_min = 3.0)
+
+        val test_lineups =
+          (ev2 -> Nil) ::
+          (ev3 -> List(base_lineup)) ::
+          (ev4 -> List(lineup1)) ::
+          (ev5 -> List(lineup2)) ::
+          Nil
+        val test_lineups_in = test_lineups.map { case (ev, l) => ConcurrentClump(ev :: Nil, l) }
+
+        TestUtils.inside(
+          StateUtils.foldLeft(test_lineups_in, PossState.init, concurrent_event_handler[PossState]) {
+            case StateEvent.Next(ctx, state, clump) =>
+              ctx.stateChange(state, clump)
+            case StateEvent.Complete(ctx, _) =>
+              ctx.noChange
+          }
+        ) {
+          case FoldStateComplete(_,
+            ConcurrentClump(`ev2` :: Nil, Nil) ::
+            ConcurrentClump(`ev3` :: `ev4` :: Nil, `base_lineup` :: `lineup1` :: Nil) ::
+            ConcurrentClump(`ev5` :: Nil, `lineup2` :: Nil) ::
+            Nil
+          ) =>
+        }
       }
 
-      "TODO" - {
-//TODO TOTEST
+      "PossCalcFragment" - {
+        val frag1 = PossCalcFragment(1, 2, 3, 4, 5, 6, 7, 8)
+        val frag2 = PossCalcFragment(1, 3, 5, 7, 9, 11, 13, 15)
+        val frag_sum = PossCalcFragment(2, 5, 8, 11, 14, 17, 20, 23)
+
+        frag1.sum(frag2) ==> frag_sum
+        frag1.total_poss ==> 2
+        frag1.summary ==> "total=[2] = shots=[1] - (orbs=[2] + db_orbs=[3]) + (ft_sets=[4] - techs=[6]) + to=[8] { +1s=[5] offset_techs=[7] }"
+      }
+
+      "calculate_stats" - {
+
+        val empty_fragment = PossCalcFragment()
+        // Tests:
+        val tests =
+          // Shots made/missed
+          List(Events.made_team, Events.missed_team, Events.made_team) ->
+            empty_fragment.copy(shots_made_or_missed = 3) ::
+          List(Events.missed_team) ->
+            empty_fragment.copy(shots_made_or_missed = 1) ::
+          List(Events.made_opponent, Events.missed_opponent) ->
+            empty_fragment ::
+          // Free throws
+          List(Events.made_ft1_team, Events.missed_ft1_team) ->
+            empty_fragment.copy(ft_events = 1) ::
+          List(Events.made_ft_team, Events.missed_ft_team) -> //(legacy format)
+            empty_fragment.copy(ft_events = 1) ::
+          List(Events.made_ft2_team) -> //(only FT1s count)
+            empty_fragment ::
+          List(Events.made_ft1_team, Events.made_ft1_team, Events.made_ft1_team, Events.made_ft1_team) ->
+            empty_fragment.copy(ft_events = 1) :: //(at most one FT set per clump)
+          List(Events.made_ft_team, Events.made_ft_team, Events.made_ft_team, Events.made_ft_team) ->
+            empty_fragment.copy(ft_events = 1) :: //(at most one FT set per clump)
+          List(Events.made_ft1_opponent, Events.missed_ft_opponent) ->
+            empty_fragment ::
+          // Free throws that definitely _aren't_ and-1s:
+          List(Events.missed_ft1_team) -> //(not all single FTs are and-1s)
+            empty_fragment.copy(ft_events = 1) ::
+          List(Events.missed_ft_team) -> //(not all single FTs are and-1s; legacy)
+            empty_fragment.copy(ft_events = 1) ::
+          List(Events.made_ft1_team) -> //(not all single FTs are and-1s; legacy)
+            empty_fragment.copy(ft_events = 1) ::
+          List(Events.made_ft_team) -> //(not all single FTs are and-1s; legacy)
+            empty_fragment.copy(ft_events = 1) ::
+          List(Events.made_ft1_team, Events.missed_ft1_team, Events.made_team) -> //(2 FTs so ignore make)
+            empty_fragment.copy(shots_made_or_missed = 1, ft_events = 1) ::
+          List(Events.made_ft_team, Events.missed_ft_team, Events.made_team) -> //(2 FTs so ignore make; legacy)
+            empty_fragment.copy(shots_made_or_missed = 1, ft_events = 1) ::
+          List(Events.made_ft1_team, Events.missed_team) -> //(missed so ignore 1 FT; legacy)
+            empty_fragment.copy(shots_made_or_missed = 1, ft_events = 1) ::
+          List(Events.made_ft_team, Events.missed_team) -> //(missed so ignore 1 FT; legacy)
+            empty_fragment.copy(shots_made_or_missed = 1, ft_events = 1) ::
+          // and-1s (see also above/below-under-prev-testing)
+          List(Events.made_ft1_team, Events.made_team) ->
+            empty_fragment.copy(shots_made_or_missed = 1, ignored_and_ones = 1) ::
+          List(Events.made_ft_team, Events.made_team) -> //(legacy)
+            empty_fragment.copy(shots_made_or_missed = 1, ignored_and_ones = 1) ::
+          List(Events.missed_ft1_team, Events.made_team) ->
+            empty_fragment.copy(shots_made_or_missed = 1, ignored_and_ones = 1) ::
+          List(Events.missed_ft_team, Events.made_team) -> //(legacy)
+            empty_fragment.copy(shots_made_or_missed = 1, ignored_and_ones = 1) ::
+          List(Events.missed_ft1_opponent, Events.made_opponent) ->
+            empty_fragment ::
+          List(Events.missed_ft_opponent, Events.made_opponent) -> //(legacy)
+            empty_fragment ::
+          // offsetting techs/flagrants
+          List(Events.tech_team, Events.tech_opponent) ->
+            empty_fragment.copy(offsetting_bad_fouls = 1) ::
+          List(Events.flagrant_team, Events.flagrant_opponent) ->
+            empty_fragment.copy(offsetting_bad_fouls = 1) ::
+          List(Events.tech_team, Events.tech_opponent, Events.tech_team, Events.tech_opponent) ->
+            empty_fragment.copy(offsetting_bad_fouls = 1) :: //(counts at most for one)
+          List(Events.tech_team, Events.tech_opponent, Events.flagrant_team, Events.flagrant_opponent) ->
+            empty_fragment.copy(offsetting_bad_fouls = 1) :: //(counts at most for one)
+          List(Events.flagrant_team, Events.flagrant_opponent, Events.flagrant_team, Events.flagrant_opponent) ->
+            empty_fragment.copy(offsetting_bad_fouls = 1) :: //(counts at most for one)
+          // non-offsetting techs/flagrants
+          List(Events.flagrant_team, Events.tech_opponent) ->
+            empty_fragment.copy(bad_fouls = 1) ::
+          List(Events.tech_team, Events.flagrant_opponent) ->
+            empty_fragment.copy(bad_fouls = 1) ::
+          List(Events.flagrant_opponent) ->
+            empty_fragment.copy(bad_fouls = 1) ::
+          List(Events.tech_opponent, Events.tech_opponent) ->
+            empty_fragment.copy(bad_fouls = 1) :: //(counts at most for one)
+          List(Events.flagrant_opponent, Events.flagrant_opponent) ->
+            empty_fragment.copy(bad_fouls = 1) :: //(counts at most for one)
+          List(Events.tech_opponent) ->
+            empty_fragment.copy(bad_fouls = 1) ::
+          List(Events.tech_opponent, Events.tech_opponent, Events.tech_opponent) ->
+            empty_fragment.copy(bad_fouls = 1) :: //(counts at most for one)
+          // ORBs
+          List(Events.orb_team, Events.orb_team, Events.orb_team) ->
+            empty_fragment.copy(liveball_orbs = 3) ::
+          List(Events.orb_opponent) ->
+            empty_fragment ::
+          // deadball ORBs
+          List(Events.deadball_rb_team, Events.deadball_rb_team) -> //currently only handle new format rebounds
+            empty_fragment ::
+          List(Events.deadball_orb_team, Events.deadball_orb_team) ->
+            empty_fragment.copy(actual_deadball_orbs = 2) ::
+          List(
+            Events.deadball_orb_team, Events.deadball_orb_team,
+            Events.missed_ft1_team, Events.missed_ft2_team, Events.made_ft2_team
+          ) ->
+            empty_fragment.copy(ft_events = 1) ::
+          List(
+            Events.deadball_orb_team, Events.deadball_orb_team, // mismatch vs number of misses IGNORED
+            Events.missed_ft1_team, Events.made_ft2_team, Events.missed_ft2_team
+          ) ->
+            empty_fragment.copy(ft_events = 1) ::
+          List(
+            Events.deadball_orb_team, Events.deadball_orb_team, // only miss was the last free throw
+            Events.made_ft1_team, Events.made_ft2_team, Events.missed_ft2_team.copy(
+              team = Events.missed_ft2_team.team.map(_.replace(
+                Events.missed_ft2_team.score_str, "100-100"))
+            )
+          ) ->
+            empty_fragment.copy(ft_events = 1, actual_deadball_orbs = 2) ::
+          List(Events.deadball_orb_team.copy( //ignore end of period deadball rebounds
+            team = Events.deadball_orb_team.team.map(_.replace(
+              Events.deadball_orb_team.date_str, "00:00:10"
+            ))
+          )) ->
+            empty_fragment ::
+          List(Events.deadball_orb_opponent) ->
+            empty_fragment ::
+          // turnovers
+          List(Events.turnover_team, Events.turnover_team) ->
+            empty_fragment.copy(turnovers = 2) ::
+          List(Events.turnover_opponent) ->
+            empty_fragment ::
+          // misc other events
+          List(
+            Events.jump_won_team, Events.jump_won_opponent, Events.jump_lost_opponent,
+            Events.steal_team, Events.steal_opponent, Events.drb_team, Events.drb_opponent,
+            Events.foul_team, Events.foul_opponent
+          ) ->
+            empty_fragment ::
+          Nil
+
+        // Both directions and checking prev is ignored
+        def reverse_dir: LineupEvent.RawGameEvent => LineupEvent.RawGameEvent = {
+          case LineupEvent.RawGameEvent(a, Some(b), None) => LineupEvent.RawGameEvent(a, None, Some(b))
+          case LineupEvent.RawGameEvent(a, None, Some(b)) => LineupEvent.RawGameEvent(a, Some(b), None)
+          case ev => ev
+        }
+        tests.map { case (l, out) =>
+          (l, l.map(reverse_dir), out)
+        }.foreach { case (test_in, test_in_oppo, expected_out) =>
+          TestUtils.inside(
+            (test_in,
+              calculate_stats(ConcurrentClump(test_in), ConcurrentClump(Nil), Direction.Team),
+              calculate_stats(ConcurrentClump(test_in_oppo), ConcurrentClump(Nil), Direction.Opponent),
+              calculate_stats(ConcurrentClump(Nil), ConcurrentClump(test_in), Direction.Team),
+              calculate_stats(ConcurrentClump(Nil), ConcurrentClump(test_in_oppo), Direction.Opponent)
+            )
+          ) {
+            case (_, `expected_out`, `expected_out`, `empty_fragment`, `empty_fragment`) =>
+          }
+        }
+        val test_prevs =
+          // Check use of prev in determining and-1s
+          (List(Events.made_team), List(Events.missed_ft1_team),
+            empty_fragment.copy(ignored_and_ones = 1)) ::
+          (List(Events.made_team), List(Events.made_ft1_team),
+            empty_fragment.copy(ignored_and_ones = 1)) ::
+          (List(Events.missed_team), List(Events.made_ft1_team),
+            empty_fragment.copy(ft_events = 1)) ::
+          (List(Events.made_team, Events.made_opponent), List(Events.made_ft1_team),
+            empty_fragment.copy(ft_events = 1)) ::
+          // Check use of prev in determining deadball rebounds
+          (List(Events.missed_ft1_team), List(
+            Events.deadball_orb_team, Events.deadball_orb_team, // mismatch vs number of misses IGNORED
+            Events.made_ft2_team, Events.missed_ft2_team
+          ),
+            empty_fragment) ::
+          (List(Events.made_ft1_team), List(
+            Events.deadball_orb_team, Events.deadball_orb_team, // only miss was the last free throw
+            Events.made_ft2_team, Events.missed_ft2_team.copy(
+              team = Events.missed_ft2_team.team.map(_.replace(
+                Events.missed_ft2_team.score_str, "100-100"))
+            )
+          ),
+            empty_fragment.copy(actual_deadball_orbs = 2)) ::
+          Nil
+
+          test_prevs.map { case (prev, curr, out) =>
+            (prev, prev.map(reverse_dir), curr, curr.map(reverse_dir), out)
+          }.foreach { case (prev_in, prev_in_oppo, curr_in, curr_in_oppo, expected_out) =>
+            TestUtils.inside(
+              (prev_in, curr_in,
+                calculate_stats(ConcurrentClump(curr_in), ConcurrentClump(prev_in), Direction.Team),
+                calculate_stats(ConcurrentClump(curr_in_oppo), ConcurrentClump(prev_in_oppo), Direction.Opponent)
+              )
+            ) {
+              case (_, _, `expected_out`, `expected_out`) =>
+            }
+          }
+      }
+
+      "assign_to_right_lineup" - {
+//TODO TOTEST (lineup fixed, lineup_balancer)
       }
 
       "calculate_possessions" - {

--- a/src/test/scala/org/piggottfamily/utils/StateUtilsTests.scala
+++ b/src/test/scala/org/piggottfamily/utils/StateUtilsTests.scala
@@ -40,11 +40,11 @@ object StateUtilsTests extends TestSuite {
           case StateEvent.Next(ctx, state, event) if 2 == event =>
             ctx.stateChange(state.copy(l = event.toString :: state.l))
           case StateEvent.Next(ctx, state, event) if 3 == event =>
-            ctx.constantState(List("3b", "3a"))
+            ctx.constantState(List("3a", "3b"))
           case StateEvent.Next(ctx, state, event) if 4 == event =>
             ctx.stateChange(state.copy(l = event.toString :: state.l), "4")
           case StateEvent.Next(ctx, state, event) if 5 == event =>
-            ctx.stateChange(state.copy(l = event.toString :: state.l), List("5b", "5a"))
+            ctx.stateChange(state.copy(l = event.toString :: state.l), List("5a", "5b"))
 
           case StateEvent.Complete(ctx, _) =>
             ctx.constantState("final")


### PR DESCRIPTION
Fixes #16
Fixes #2 (sort of by accident, the free throws getting put in the wrong possession made it way harder to assign possessions correctly to lineups

Took 3 attempts, and abandoning the ability to assign a possession number, but this is fairly accurate, here's validation against KP possession numbers (didn't include opposition stats here, but validated that for all but a few games the possession numbers were within 2 ... and hand checked many of them and all the >2 diff)

The discrepancies now fall into 3 categories:
* I'm right and KP is wrong :) (eg LSU game)
* Errors in the data that are non-trivial to address
* Fundamental problems with splitting possessions between lineups (eg "made shot, lineup change, rebound on missed and-1, score off rebound" .. that's 1 possession, both lineups scored off it, who do you assign the possession to?!

Anyway, the overall discrepancy is <50% of all games (+1 injected possession to avoid the lineup having score>0 with poss==0, so the overall error is ~1%)

```
Del: 72 (-2) 
[total=[70] = shots=[62] - (orbs=[15] + db_orbs=[1]) + (ft_sets=[14] - techs=[2]) + to=[12] { +1s=[2] offset_techs=[1] }]

Navy: 71
[total=[71] = shots=[59] - (orbs=[11] + db_orbs=[0]) + (ft_sets=[13] - techs=[0]) + to=[10] { +1s=[1] offset_techs=[0] }]

NCAT: 70 (-1)
[total=[69] = shots=[66] - (orbs=[15] + db_orbs=[0]) + (ft_sets=[5] - techs=[0]) + to=[12] { +1s=[5] offset_techs=[0] }]

MSM: 74 (-2)
[total=[72] = shots=[61] - (orbs=[13] + db_orbs=[0]) + (ft_sets=[7] - techs=[1]) + to=[18] { +1s=[3] offset_techs=[0] }]

Hofstra: 65 (-1)
[total=[64] = shots=[64] - (orbs=[16] + db_orbs=[0]) + (ft_sets=[6] - techs=[1]) + to=[11] { +1s=[2] offset_techs=[0] }]

Marshall: 84 (+1)
[total=[85] = shots=[61] - (orbs=[13] + db_orbs=[0]) + (ft_sets=[18] - techs=[0]) + to=[19] { +1s=[0] offset_techs=[0] }]


UVA: 60 (+1)
[total=[61] = shots=[50] - (orbs=[10] + db_orbs=[0]) + (ft_sets=[7] - techs=[0]) + to=[14] { +1s=[2] offset_techs=[0] }]

PSU: 64 
[total=[64] = shots=[45] - (orbs=[10] + db_orbs=[0]) + (ft_sets=[12] - techs=[0]) + to=[17] { +1s=[2] offset_techs=[0] }]

Loyola: 61
[total=[61] = shots=[47] - (orbs=[5] + db_orbs=[0]) + (ft_sets=[4] - techs=[0]) + to=[15] { +1s=[0] offset_techs=[0] }]

Purdue: 65 (-1)
[total=[64] = shots=[57] - (orbs=[16] + db_orbs=[1]) + (ft_sets=[7] - techs=[0]) + to=[17] { +1s=[0] offset_techs=[0] }]

Loyola MD: 
[total=[71] = shots=[68] - (orbs=[14] + db_orbs=[0]) + (ft_sets=[9] - techs=[0]) + to=[8] { +1s=[1] offset_techs=[0] }]

Seton Hall: 68 (+1)
[total=[69] = shots=[58] - (orbs=[10] + db_orbs=[0]) + (ft_sets=[11] - techs=[0]) + to=[10] { +1s=[0] offset_techs=[0] }]

Radford: 65 (+1)
[total=[66] = shots=[53] - (orbs=[13] + db_orbs=[0]) + (ft_sets=[12] - techs=[0]) + to=[14] { +1s=[2] offset_techs=[0] }]

Neb: 65 (+1)
[total=[66] = shots=[60] - (orbs=[14] + db_orbs=[0]) + (ft_sets=[7] - techs=[0]) + to=[13] { +1s=[1] offset_techs=[0] }]

Rutgers: 72
[total=[72] = shots=[58] - (orbs=[6] + db_orbs=[0]) + (ft_sets=[9] - techs=[0]) + to=[11] { +1s=[3] offset_techs=[0] }]

Minn: 66 (-1)
[total=[65] = shots=[48] - (orbs=[7] + db_orbs=[0]) + (ft_sets=[13] - techs=[0]) + to=[11] { +1s=[0] offset_techs=[0] }]

Indiana: 65 (-1)
[total=[64] = shots=[63] - (orbs=[18] + db_orbs=[0]) + (ft_sets=[10] - techs=[0]) + to=[9] { +1s=[1] offset_techs=[0] }]


Wisc: 61 (+1)
[total=[62] = shots=[47] - (orbs=[10] + db_orbs=[0]) + (ft_sets=[15] - techs=[0]) + to=[10] { +1s=[1] offset_techs=[0] }]

Ohio St: 65 (-1)
[total=[64] = shots=[43] - (orbs=[4] + db_orbs=[0]) + (ft_sets=[6] - techs=[0]) + to=[19] { +1s=[3] offset_techs=[0] }]

MSU: 62 
[total=[62] = shots=[61] - (orbs=[14] + db_orbs=[0]) + (ft_sets=[3] - techs=[0]) + to=[12] { +1s=[2] offset_techs=[0] }]

Illinois: 71 (-1)
[total=[70] = shots=[45] - (orbs=[6] + db_orbs=[3]) + (ft_sets=[13] - techs=[0]) + to=[21] { +1s=[1] offset_techs=[0] }]

NWU: 65  (-2) ********
[total=[63] = shots=[54] - (orbs=[10] + db_orbs=[0]) + (ft_sets=[8] - techs=[0]) + to=[11] { +1s=[2] offset_techs=[0] }]

Wisconsin: 61
[total=[61] = shots=[56] - (orbs=[10] + db_orbs=[1]) + (ft_sets=[4] - techs=[0]) + to=[12] { +1s=[1] offset_techs=[0] }]

Nebraska: 64 (+2)
[total=[66] = shots=[58] - (orbs=[12] + db_orbs=[0]) + (ft_sets=[10] - techs=[0]) + to=[10] { +1s=[0] offset_techs=[0] }]
<—
[total=[65] = shots=[58] - (orbs=[12] + db_orbs=[0]) + (ft_sets=[9] - techs=[0]) + to=[10] { +1s=[1] offset_techs=[0] }]

Purdue: 65 (-1)
[total=[64] = shots=[52] - (orbs=[5] + db_orbs=[0]) + (ft_sets=[6] - techs=[0]) + to=[11] { +1s=[3] offset_techs=[0] }]

Mich: 64 (-1)
[total=[63] = shots=[55] - (orbs=[11] + db_orbs=[0]) + (ft_sets=[3] - techs=[0]) + to=[16] { +1s=[2] offset_techs=[0] }]

Iowa: 65 (+1)
[total=[66] = shots=[53] - (orbs=[10] + db_orbs=[0]) + (ft_sets=[6] - techs=[0]) + to=[17] { +1s=[0] offset_techs=[0] }]

Ohio St: 64 (-1)
[total=[63] = shots=[47] - (orbs=[10] + db_orbs=[0]) + (ft_sets=[11] - techs=[0]) + to=[15] { +1s=[1] offset_techs=[0] }]

PSU: 69 
[total=[69] = shots=[56] - (orbs=[10] + db_orbs=[0]) + (ft_sets=[6] - techs=[0]) + to=[17] { +1s=[3] offset_techs=[0] }]

Mich: 58
[total=[58] = shots=[58] - (orbs=[13] + db_orbs=[0]) + (ft_sets=[4] - techs=[0]) + to=[9] { +1s=[2] offset_techs=[0] }]

Minnesota: 65 (-1)
[total=[64] = shots=[62] - (orbs=[13] + db_orbs=[1]) + (ft_sets=[6] - techs=[0]) + to=[10] { +1s=[0] offset_techs=[0] }]

Nebraska: 64 (-1)
[total=[63] = shots=[50] - (orbs=[7] + db_orbs=[1]) + (ft_sets=[10] - techs=[0]) + to=[11] { +1s=[3] offset_techs=[0] }]

Belmont: 69 (-2)
[total=[67] = shots=[69] - (orbs=[15] + db_orbs=[0]) + (ft_sets=[8] - techs=[0]) + to=[5] { +1s=[4] offset_techs=[0] }]

LSU: 72 (-3!!) 
[total=[69] = shots=[63] - (orbs=[14] + db_orbs=[3]) + (ft_sets=[11] - techs=[0]) + to=[12] { +1s=[1] offset_techs=[0] }]

total: 
-14 possessions over 33 games
3: LSU (I think I’m right)
2: Belmont, Neb, NWU, MSM, Del (I’m partly right)

```

